### PR TITLE
chore: replace uv commands with Makefile commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,9 +11,14 @@
 
 | コマンド | 説明 |
 |---|---|
-| `uv run python -m pytest` | テスト実行 |
-| `uv run ruff check .` | Lint |
-| `uv run ruff check --fix .` | Lint (自動修正) |
-| `uv run ruff format .` | フォーマット |
-| `uv run ty check` | 型チェック |
-| `uv run pre-commit run --all-files` | 全フック実行 |
+| `make build-dev` | 開発用 Docker イメージをビルド |
+| `make build-prod` | 本番用 Docker イメージをビルド |
+| `make build` | 開発用・本番用の両方をビルド |
+| `make run-dev` | 開発コンテナを起動（バインドマウント） |
+| `make run-prod` | 本番コンテナを起動 |
+| `make test` | テスト実行（pytest） |
+| `make lint` | Lint（ruff check） |
+| `make lint-fix` | Lint 自動修正（ruff check --fix） |
+| `make format` | フォーマット（ruff format） |
+| `make shell` | 開発コンテナのシェルを開く |
+| `make help` | 利用可能なコマンド一覧を表示 |


### PR DESCRIPTION
## 概要
CLAUDE.md のコマンドテーブルを、直接の uv run コマンドから Makefile 経由の make コマンドに置き換える。
Makefile の全コマンド（build, run, test, lint, format, shell, help）を網羅。