### PR TITLE
feat: add Silero VAD speech detection module

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -5,11 +5,25 @@ from voice_auth_engine.audio_preprocessor import (
     UnsupportedFormatError,
     load_audio,
 )
+from voice_auth_engine.vad import (
+    SpeechSegment,
+    SpeechSegments,
+    VadError,
+    VadModelLoadError,
+    detect_speech,
+    extract_speech,
+)
 
 __all__ = [
     "AudioData",
     "AudioDecodeError",
     "AudioPreprocessError",
+    "SpeechSegment",
+    "SpeechSegments",
     "UnsupportedFormatError",
+    "VadError",
+    "VadModelLoadError",
+    "detect_speech",
+    "extract_speech",
     "load_audio",
 ]

--- a/src/voice_auth_engine/vad.py
+++ b/src/voice_auth_engine/vad.py
@@ -1,0 +1,132 @@
+"""Silero VAD による音声区間検出。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+import sherpa_onnx
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.model_config import silero_vad_config
+
+
+class VadError(Exception):
+    """VAD 処理の基底例外。"""
+
+
+class VadModelLoadError(VadError):
+    """VAD モデルの読み込み失敗。"""
+
+
+class SpeechSegment(NamedTuple):
+    """検出された発話区間。"""
+
+    start_sample: int  # 開始サンプルインデックス
+    end_sample: int  # 終了サンプルインデックス (exclusive)
+    start_sec: float  # 開始時刻 (秒)
+    end_sec: float  # 終了時刻 (秒)
+
+
+class SpeechSegments(NamedTuple):
+    """発話区間検出の結果。"""
+
+    segments: list[SpeechSegment]
+    audio: AudioData  # 元の音声データへの参照
+
+
+def detect_speech(
+    audio: AudioData,
+    *,
+    model_path: str | Path | None = None,
+    threshold: float = 0.5,
+    min_speech_duration: float = 0.25,
+    min_silence_duration: float = 0.5,
+) -> SpeechSegments:
+    """音声データから発話区間を検出する。
+
+    Args:
+        audio: 前処理済み音声データ（16kHz モノラル int16）。
+        model_path: Silero VAD モデルファイルのパス。None の場合はデフォルトを使用。
+        threshold: 発話検出の閾値（0.0〜1.0）。
+        min_speech_duration: 最小発話持続時間（秒）。
+        min_silence_duration: 最小無音持続時間（秒）。
+
+    Returns:
+        SpeechSegments: 検出された発話区間のリストと元の音声データ。
+
+    Raises:
+        VadModelLoadError: モデルの読み込みに失敗した場合。
+    """
+    if model_path is None:
+        model_path = silero_vad_config.path
+    model_path = Path(model_path)
+
+    if not model_path.exists():
+        raise VadModelLoadError(f"VAD モデルファイルが見つかりません: {model_path}")
+
+    config = sherpa_onnx.VadModelConfig(
+        silero_vad=sherpa_onnx.SileroVadModelConfig(
+            model=str(model_path),
+            threshold=threshold,
+            min_speech_duration=min_speech_duration,
+            min_silence_duration=min_silence_duration,
+        ),
+        sample_rate=audio.sample_rate,
+    )
+
+    try:
+        vad = sherpa_onnx.VoiceActivityDetector(config)
+    except Exception as exc:
+        raise VadModelLoadError(f"VAD モデルの読み込みに失敗しました: {exc}") from exc
+
+    if len(audio.samples) == 0:
+        return SpeechSegments(segments=[], audio=audio)
+
+    # int16 → float32 正規化 (Silero VAD は [-1, 1] の float32 を期待)
+    samples_f32 = audio.samples.astype(np.float32) / 32768.0
+
+    vad.accept_waveform(samples_f32)
+    vad.flush()
+
+    segments: list[SpeechSegment] = []
+    while not vad.empty():
+        seg = vad.front
+        start_sample = seg.start
+        end_sample = start_sample + len(seg.samples)
+        # end_sample が音声長を超えないようにクランプ
+        end_sample = min(end_sample, len(audio.samples))
+        segments.append(
+            SpeechSegment(
+                start_sample=start_sample,
+                end_sample=end_sample,
+                start_sec=start_sample / audio.sample_rate,
+                end_sec=end_sample / audio.sample_rate,
+            )
+        )
+        vad.pop()
+
+    return SpeechSegments(segments=segments, audio=audio)
+
+
+def extract_speech(segments: SpeechSegments) -> AudioData:
+    """検出された発話区間の音声を切り出して結合する。
+
+    Args:
+        segments: detect_speech の結果。
+
+    Returns:
+        AudioData: 発話区間のみを結合した音声データ。
+    """
+    if not segments.segments:
+        return AudioData(
+            samples=np.array([], dtype=np.int16),
+            sample_rate=segments.audio.sample_rate,
+        )
+
+    parts = [segments.audio.samples[seg.start_sample : seg.end_sample] for seg in segments.segments]
+    return AudioData(
+        samples=np.concatenate(parts),
+        sample_rate=segments.audio.sample_rate,
+    )

--- a/tests/audio_factory.py
+++ b/tests/audio_factory.py
@@ -1,4 +1,4 @@
-"""テスト用音声ファイル生成ヘルパー。"""
+"""テスト用音声データ・ファイル生成ヘルパー。"""
 
 from __future__ import annotations
 
@@ -7,6 +7,47 @@ from pathlib import Path
 import av
 import av.audio
 import numpy as np
+import numpy.typing as npt
+
+from voice_auth_engine.audio_preprocessor import AudioData
+
+TARGET_SAMPLE_RATE = 16000
+
+
+def generate_voiced_samples(
+    *,
+    sample_rate: int = TARGET_SAMPLE_RATE,
+    duration: float = 1.0,
+    f0: float = 150.0,
+) -> npt.NDArray[np.int16]:
+    """VAD が反応する発話風の複合信号を生成する。
+
+    基本周波数 + 倍音の複合信号。単純なサイン波では VAD が反応しない。
+    """
+    n = int(sample_rate * duration)
+    t = np.linspace(0, duration, n, endpoint=False, dtype=np.float32)
+    signal = np.zeros(n, dtype=np.float32)
+    for h in range(1, 6):
+        signal += (1.0 / h) * np.sin(2 * np.pi * f0 * h * t)
+    signal /= np.max(np.abs(signal))
+    return (signal * 30000).astype(np.int16)
+
+
+def generate_silence_samples(
+    *,
+    sample_rate: int = TARGET_SAMPLE_RATE,
+    duration: float = 1.0,
+) -> npt.NDArray[np.int16]:
+    """無音信号を生成する。"""
+    return np.zeros(int(sample_rate * duration), dtype=np.int16)
+
+
+def make_audio_data(
+    samples: npt.NDArray[np.int16],
+    sample_rate: int = TARGET_SAMPLE_RATE,
+) -> AudioData:
+    """AudioData を生成する。"""
+    return AudioData(samples=samples, sample_rate=sample_rate)
 
 
 def generate_audio_file(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,9 +4,17 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from .audio_factory import generate_audio_file
+from voice_auth_engine.audio_preprocessor import AudioData
+
+from .audio_factory import (
+    generate_audio_file,
+    generate_silence_samples,
+    generate_voiced_samples,
+    make_audio_data,
+)
 
 
 @pytest.fixture
@@ -59,3 +67,21 @@ def webm_file(tmp_audio_dir: Path) -> Path:
         codec="libopus",
         format_name="webm",
     )
+
+
+@pytest.fixture
+def voiced_audio() -> AudioData:
+    """1秒の発話風 AudioData。"""
+    return make_audio_data(generate_voiced_samples(duration=1.0))
+
+
+@pytest.fixture
+def silence_audio() -> AudioData:
+    """1秒の無音 AudioData。"""
+    return make_audio_data(generate_silence_samples(duration=1.0))
+
+
+@pytest.fixture
+def empty_audio() -> AudioData:
+    """空の AudioData。"""
+    return make_audio_data(np.array([], dtype=np.int16))

--- a/tests/test_vad.py
+++ b/tests/test_vad.py
@@ -1,0 +1,143 @@
+"""VAD モジュールのテスト。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.model_config import silero_vad_config
+from voice_auth_engine.vad import (
+    SpeechSegment,
+    SpeechSegments,
+    VadModelLoadError,
+    detect_speech,
+    extract_speech,
+)
+
+from .audio_factory import generate_silence_samples, generate_voiced_samples, make_audio_data
+
+SAMPLE_RATE = 16000
+
+
+@pytest.mark.skipif(not silero_vad_config.path.exists(), reason="Silero VAD model not found")
+class TestDetectSpeech:
+    """detect_speech 関数のテスト。"""
+
+    def test_detects_speech_in_voiced_signal(self, voiced_audio: AudioData) -> None:
+        """発話風信号で検出される。"""
+        result = detect_speech(voiced_audio)
+        assert len(result.segments) > 0
+
+    def test_no_speech_in_silence(self, silence_audio: AudioData) -> None:
+        """無音で空リスト。"""
+        result = detect_speech(silence_audio)
+        assert len(result.segments) == 0
+
+    def test_speech_surrounded_by_silence(self) -> None:
+        """無音+発話+無音の区間検出。"""
+        silence = generate_silence_samples(duration=0.5)
+        voiced = generate_voiced_samples(duration=1.0)
+        audio = make_audio_data(np.concatenate([silence, voiced, silence]))
+        result = detect_speech(audio)
+        assert len(result.segments) >= 1
+        seg = result.segments[0]
+        assert seg.start_sec >= 0.3
+
+    def test_returns_audio_in_result(self, voiced_audio: AudioData) -> None:
+        """結果に元音声を含む。"""
+        result = detect_speech(voiced_audio)
+        assert result.audio is voiced_audio
+
+    def test_audio_shorter_than_window_size(self) -> None:
+        """512未満でもクラッシュしない。"""
+        audio = make_audio_data(generate_voiced_samples(duration=0.01))  # 160 samples < 512
+        result = detect_speech(audio)
+        assert isinstance(result, SpeechSegments)
+
+    def test_empty_audio(self, empty_audio: AudioData) -> None:
+        """空音声で空リスト。"""
+        result = detect_speech(empty_audio)
+        assert len(result.segments) == 0
+
+    def test_custom_threshold(self, voiced_audio: AudioData) -> None:
+        """threshold パラメータ動作。"""
+        result_high = detect_speech(voiced_audio, threshold=0.99)
+        result_low = detect_speech(voiced_audio, threshold=0.1)
+        assert len(result_high.segments) <= len(result_low.segments)
+
+    def test_segment_timestamps_are_consistent(self, voiced_audio: AudioData) -> None:
+        """サンプル↔秒の整合性。"""
+        result = detect_speech(voiced_audio)
+        for seg in result.segments:
+            assert seg.start_sec == pytest.approx(seg.start_sample / SAMPLE_RATE)
+            assert seg.end_sec == pytest.approx(seg.end_sample / SAMPLE_RATE)
+
+    def test_segment_end_does_not_exceed_length(self, voiced_audio: AudioData) -> None:
+        """範囲外なし。"""
+        result = detect_speech(voiced_audio)
+        for seg in result.segments:
+            assert seg.end_sample <= len(voiced_audio.samples)
+
+    def test_model_path_not_found(self, voiced_audio: AudioData) -> None:
+        """不正パスで VadModelLoadError。"""
+        with pytest.raises(VadModelLoadError):
+            detect_speech(voiced_audio, model_path="/nonexistent/model.onnx")
+
+
+@pytest.mark.skipif(not silero_vad_config.path.exists(), reason="Silero VAD model not found")
+class TestExtractSpeech:
+    """extract_speech 関数のテスト。"""
+
+    def test_extracts_single_segment(self, voiced_audio: AudioData) -> None:
+        """単一区間の切り出し。"""
+        segments = SpeechSegments(
+            segments=[SpeechSegment(1000, 5000, 1000 / SAMPLE_RATE, 5000 / SAMPLE_RATE)],
+            audio=voiced_audio,
+        )
+        result = extract_speech(segments)
+        assert len(result.samples) == 4000
+
+    def test_extracts_multiple_segments(self, voiced_audio: AudioData) -> None:
+        """複数区間の結合。"""
+        segments = SpeechSegments(
+            segments=[
+                SpeechSegment(1000, 3000, 1000 / SAMPLE_RATE, 3000 / SAMPLE_RATE),
+                SpeechSegment(5000, 7000, 5000 / SAMPLE_RATE, 7000 / SAMPLE_RATE),
+            ],
+            audio=voiced_audio,
+        )
+        result = extract_speech(segments)
+        assert len(result.samples) == 4000
+
+    def test_empty_segments_returns_empty_audio(self, voiced_audio: AudioData) -> None:
+        """空セグメント → 空音声。"""
+        segments = SpeechSegments(segments=[], audio=voiced_audio)
+        result = extract_speech(segments)
+        assert len(result.samples) == 0
+
+    def test_output_preserves_sample_rate(self, voiced_audio: AudioData) -> None:
+        """サンプルレート維持。"""
+        segments = SpeechSegments(
+            segments=[SpeechSegment(0, 8000, 0.0, 0.5)],
+            audio=voiced_audio,
+        )
+        result = extract_speech(segments)
+        assert result.sample_rate == SAMPLE_RATE
+
+    def test_output_dtype_is_int16(self, voiced_audio: AudioData) -> None:
+        """dtype 維持。"""
+        segments = SpeechSegments(
+            segments=[SpeechSegment(0, 8000, 0.0, 0.5)],
+            audio=voiced_audio,
+        )
+        result = extract_speech(segments)
+        assert result.samples.dtype == np.int16
+
+    def test_roundtrip_detect_then_extract(self, voiced_audio: AudioData) -> None:
+        """detect → extract の統合テスト。"""
+        segments = detect_speech(voiced_audio)
+        result = extract_speech(segments)
+        assert len(result.samples) > 0
+        assert result.sample_rate == SAMPLE_RATE
+        assert result.samples.dtype == np.int16


### PR DESCRIPTION
## 概要

音声認証パイプラインの前段として、Silero VAD による発話区間検出モジュールを追加する。

- `detect_speech`: sherpa-onnx の VoiceActivityDetector を使用して音声データから発話区間を検出
- `extract_speech`: 検出された発話区間を切り出して結合
- テスト用の合成音声ヘルパー（`generate_voiced_samples`, `generate_silence_samples`）を `audio_factory` に追加し、共通フィクスチャ化