### PR TITLE
chore: require English in commit-message command

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -12,3 +12,4 @@
 
 - 1行目: 変更の要約（Conventional Commits 形式: `feat:`, `fix:`, `refactor:`, `chore:`, `docs:` など）
 - 必要に応じて空行の後に補足説明を追加
+- **すべて英語で記述する**


### PR DESCRIPTION
## 概要

commit-message コマンドのコミットメッセージ形式に「すべて英語で記述する」ルールを追加。