### PR TITLE
feat: add SenseVoice speech recognition module

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -5,6 +5,13 @@ from voice_auth_engine.audio_preprocessor import (
     UnsupportedFormatError,
     load_audio,
 )
+from voice_auth_engine.speech_recognizer import (
+    RecognitionError,
+    RecognizerModelLoadError,
+    SpeechRecognizerError,
+    TranscriptionResult,
+    transcribe,
+)
 from voice_auth_engine.vad import (
     SpeechSegment,
     SpeechSegments,
@@ -18,12 +25,17 @@ __all__ = [
     "AudioData",
     "AudioDecodeError",
     "AudioPreprocessError",
+    "RecognitionError",
+    "RecognizerModelLoadError",
+    "SpeechRecognizerError",
     "SpeechSegment",
     "SpeechSegments",
+    "TranscriptionResult",
     "UnsupportedFormatError",
     "VadError",
     "VadModelLoadError",
     "detect_speech",
     "extract_speech",
     "load_audio",
+    "transcribe",
 ]

--- a/src/voice_auth_engine/speech_recognizer.py
+++ b/src/voice_auth_engine/speech_recognizer.py
@@ -1,0 +1,91 @@
+"""SenseVoice による音声認識。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+import sherpa_onnx
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.model_config import sense_voice_config
+
+
+class SpeechRecognizerError(Exception):
+    """音声認識の基底例外。"""
+
+
+class RecognizerModelLoadError(SpeechRecognizerError):
+    """音声認識モデルの読み込み失敗。"""
+
+
+class RecognitionError(SpeechRecognizerError):
+    """音声認識処理の失敗。"""
+
+
+class TranscriptionResult(NamedTuple):
+    """音声認識結果。"""
+
+    text: str  # 認識テキスト
+
+
+def transcribe(
+    audio: AudioData,
+    *,
+    model_dir: str | Path | None = None,
+    language: str = "ja",
+) -> TranscriptionResult:
+    """音声データからテキストを認識する。
+
+    Args:
+        audio: 前処理済み音声データ（16kHz モノラル int16）。
+        model_dir: SenseVoice モデルディレクトリのパス。
+            None の場合は sense_voice_config.path を使用。
+            ディレクトリ内に model.int8.onnx と tokens.txt が必要。
+        language: 認識言語。デフォルトは "ja"（日本語）。
+
+    Returns:
+        TranscriptionResult: 認識されたテキスト。
+
+    Raises:
+        RecognizerModelLoadError: モデルの読み込みに失敗した場合。
+        RecognitionError: 音声認識処理に失敗した場合。
+    """
+    if model_dir is None:
+        model_dir = sense_voice_config.path
+    model_dir = Path(model_dir)
+
+    if not model_dir.exists():
+        raise RecognizerModelLoadError(
+            f"SenseVoice モデルディレクトリが見つかりません: {model_dir}"
+        )
+
+    model_file = model_dir / "model.int8.onnx"
+    tokens_file = model_dir / "tokens.txt"
+
+    if not model_file.exists():
+        raise RecognizerModelLoadError(f"モデルファイルが見つかりません: {model_file}")
+    if not tokens_file.exists():
+        raise RecognizerModelLoadError(f"トークンファイルが見つかりません: {tokens_file}")
+
+    if len(audio.samples) == 0:
+        raise RecognitionError("空の音声データは認識できません")
+
+    try:
+        recognizer = sherpa_onnx.OfflineRecognizer.from_sense_voice(
+            model=str(model_file),
+            tokens=str(tokens_file),
+            language=language,
+        )
+    except Exception as exc:
+        raise RecognizerModelLoadError(f"SenseVoice モデルの読み込みに失敗しました: {exc}") from exc
+
+    # int16 → float32 正規化
+    samples_f32 = audio.samples.astype(np.float32) / 32768.0
+
+    stream = recognizer.create_stream()
+    stream.accept_waveform(audio.sample_rate, samples_f32)
+    recognizer.decode_stream(stream)
+
+    return TranscriptionResult(text=stream.result.text.strip())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.audio_preprocessor import AudioData
-from voice_auth_engine.model_config import silero_vad_config
+from voice_auth_engine.model_config import sense_voice_config, silero_vad_config
 
 from .audio_factory import (
     generate_audio_file,
@@ -19,6 +19,10 @@ from .audio_factory import (
 
 requires_vad_model = pytest.mark.skipif(
     not silero_vad_config.path.exists(), reason="Silero VAD model not found"
+)
+
+requires_sense_voice_model = pytest.mark.skipif(
+    not sense_voice_config.path.exists(), reason="SenseVoice model not found"
 )
 
 

--- a/tests/test_speech_recognizer.py
+++ b/tests/test_speech_recognizer.py
@@ -1,0 +1,58 @@
+"""speech_recognizer モジュールのテスト。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.speech_recognizer import (
+    RecognitionError,
+    RecognizerModelLoadError,
+    TranscriptionResult,
+    transcribe,
+)
+
+from .conftest import requires_sense_voice_model
+
+
+class TestTranscribe:
+    """transcribe 関数のテスト。"""
+
+    def test_model_dir_not_found(self, voiced_audio: AudioData) -> None:
+        """不正パスで RecognizerModelLoadError が発生する。"""
+        with pytest.raises(RecognizerModelLoadError, match="ディレクトリが見つかりません"):
+            transcribe(voiced_audio, model_dir="/nonexistent/path")
+
+    def test_model_file_missing(
+        self, voiced_audio: AudioData, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """ディレクトリはあるが onnx ファイルがない場合。"""
+        with pytest.raises(RecognizerModelLoadError, match="モデルファイルが見つかりません"):
+            transcribe(voiced_audio, model_dir=str(tmp_path))
+
+    @requires_sense_voice_model
+    def test_transcribes_voiced_audio(self, voiced_audio: AudioData) -> None:
+        """発話風音声で空でないテキストを返す。"""
+        result = transcribe(voiced_audio)
+        assert isinstance(result.text, str)
+        assert len(result.text) > 0
+
+    @requires_sense_voice_model
+    def test_result_type(self, voiced_audio: AudioData) -> None:
+        """戻り値が TranscriptionResult である。"""
+        result = transcribe(voiced_audio)
+        assert isinstance(result, TranscriptionResult)
+
+    @requires_sense_voice_model
+    def test_empty_audio_raises_error(self) -> None:
+        """空音声で RecognitionError が発生する。"""
+        empty = AudioData(samples=np.array([], dtype=np.int16), sample_rate=16000)
+        with pytest.raises(RecognitionError, match="空の音声データ"):
+            transcribe(empty)
+
+    @requires_sense_voice_model
+    def test_custom_language(self, voiced_audio: AudioData) -> None:
+        """language パラメータが受け付けられる。"""
+        result = transcribe(voiced_audio, language="en")
+        assert isinstance(result, TranscriptionResult)


### PR DESCRIPTION
## 概要

SenseVoice (sherpa-onnx) を使用した音声認識モジュールを追加。
認証判定には使わず、発話内容の音素多様性チェック（品質ゲート）のために使用する。

- `speech_recognizer.py`: `transcribe` 関数、例外クラス、`TranscriptionResult` 型
- `test_speech_recognizer.py`: モデル不要テスト 2件 + モデル必要テスト 4件
- `conftest.py`: `requires_sense_voice_model` マーカー追加
- `__init__.py`: エクスポート追加

Closes #18