### PR TITLE
feat: add CAM++ speaker embedding extraction module (#19)

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -5,6 +5,13 @@ from voice_auth_engine.audio_preprocessor import (
     UnsupportedFormatError,
     load_audio,
 )
+from voice_auth_engine.embedding_extractor import (
+    Embedding,
+    EmbeddingExtractionError,
+    EmbeddingExtractorError,
+    EmbeddingModelLoadError,
+    extract_embedding,
+)
 from voice_auth_engine.speech_recognizer import (
     RecognitionError,
     RecognizerModelLoadError,
@@ -25,6 +32,10 @@ __all__ = [
     "AudioData",
     "AudioDecodeError",
     "AudioPreprocessError",
+    "Embedding",
+    "EmbeddingExtractionError",
+    "EmbeddingExtractorError",
+    "EmbeddingModelLoadError",
     "RecognitionError",
     "RecognizerModelLoadError",
     "SpeechRecognizerError",
@@ -35,6 +46,7 @@ __all__ = [
     "VadError",
     "VadModelLoadError",
     "detect_speech",
+    "extract_embedding",
     "extract_speech",
     "load_audio",
     "transcribe",

--- a/src/voice_auth_engine/embedding_extractor.py
+++ b/src/voice_auth_engine/embedding_extractor.py
@@ -1,0 +1,84 @@
+"""CAM++ (3D-Speaker) による話者埋め込みベクトル抽出。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import NamedTuple
+
+import numpy as np
+import numpy.typing as npt
+import sherpa_onnx
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.model_config import campplus_config
+
+
+class EmbeddingExtractorError(Exception):
+    """埋め込み抽出の基底例外。"""
+
+
+class EmbeddingModelLoadError(EmbeddingExtractorError):
+    """埋め込みモデルの読み込み失敗。"""
+
+
+class EmbeddingExtractionError(EmbeddingExtractorError):
+    """埋め込み抽出処理の失敗。"""
+
+
+class Embedding(NamedTuple):
+    """話者埋め込みベクトル。"""
+
+    values: npt.NDArray[np.float32]
+
+
+def extract_embedding(
+    audio: AudioData,
+    *,
+    model_path: str | Path | None = None,
+) -> Embedding:
+    """音声データから話者埋め込みベクトルを抽出する。
+
+    Args:
+        audio: 前処理済み音声データ（16kHz モノラル int16）。
+        model_path: CAM++ モデルファイルのパス。None の場合はデフォルトを使用。
+
+    Returns:
+        Embedding: 話者埋め込みベクトル。
+
+    Raises:
+        EmbeddingModelLoadError: モデルの読み込みに失敗した場合。
+        EmbeddingExtractionError: 埋め込み抽出処理に失敗した場合。
+    """
+    if model_path is None:
+        model_path = campplus_config.path
+    model_path = Path(model_path)
+
+    if not model_path.exists():
+        raise EmbeddingModelLoadError(f"埋め込みモデルファイルが見つかりません: {model_path}")
+
+    try:
+        config = sherpa_onnx.SpeakerEmbeddingExtractorConfig(model=str(model_path))
+        extractor = sherpa_onnx.SpeakerEmbeddingExtractor(config)
+    except Exception as exc:
+        raise EmbeddingModelLoadError(f"埋め込みモデルの読み込みに失敗しました: {exc}") from exc
+
+    if len(audio.samples) == 0:
+        raise EmbeddingExtractionError("空の音声データからは埋め込みを抽出できません")
+
+    # 最低 100ms の音声が必要
+    min_samples = int(audio.sample_rate * 0.1)
+    if len(audio.samples) < min_samples:
+        raise EmbeddingExtractionError("音声が短すぎて埋め込みを抽出できません")
+
+    # int16 → float32 正規化
+    samples_f32 = audio.samples.astype(np.float32) / 32768.0
+
+    stream = extractor.create_stream()
+    stream.accept_waveform(audio.sample_rate, samples_f32)
+    stream.input_finished()
+
+    if not extractor.is_ready(stream):
+        raise EmbeddingExtractionError("音声が短すぎて埋め込みを抽出できません")
+
+    values = np.array(extractor.compute(stream), dtype=np.float32)
+    return Embedding(values=values)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.audio_preprocessor import AudioData
-from voice_auth_engine.model_config import sense_voice_config, silero_vad_config
+from voice_auth_engine.model_config import campplus_config, sense_voice_config, silero_vad_config
 
 from .audio_factory import (
     generate_audio_file,
@@ -23,6 +23,10 @@ requires_vad_model = pytest.mark.skipif(
 
 requires_sense_voice_model = pytest.mark.skipif(
     not sense_voice_config.path.exists(), reason="SenseVoice model not found"
+)
+
+requires_campplus_model = pytest.mark.skipif(
+    not campplus_config.path.exists(), reason="CAM++ model not found"
 )
 
 
@@ -94,3 +98,9 @@ def silence_audio() -> AudioData:
 def empty_audio() -> AudioData:
     """空の AudioData。"""
     return make_audio_data(np.array([], dtype=np.int16))
+
+
+@pytest.fixture
+def voiced_audio_3s() -> AudioData:
+    """3秒の発話風 AudioData。"""
+    return make_audio_data(generate_voiced_samples(duration=3.0))

--- a/tests/test_embedding_extractor.py
+++ b/tests/test_embedding_extractor.py
@@ -1,0 +1,68 @@
+"""embedding_extractor モジュールのテスト。"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from voice_auth_engine.audio_preprocessor import AudioData
+from voice_auth_engine.embedding_extractor import (
+    Embedding,
+    EmbeddingExtractionError,
+    EmbeddingModelLoadError,
+    extract_embedding,
+)
+
+from .conftest import requires_campplus_model
+
+
+class TestExtractEmbedding:
+    """extract_embedding 関数のテスト。"""
+
+    def test_model_path_not_found(self, voiced_audio: AudioData) -> None:
+        """不正パスで EmbeddingModelLoadError が発生する。"""
+        with pytest.raises(EmbeddingModelLoadError, match="モデルファイルが見つかりません"):
+            extract_embedding(voiced_audio, model_path="/nonexistent/path")
+
+    @requires_campplus_model
+    def test_output_dimension(self, voiced_audio_3s: AudioData) -> None:
+        """出力ベクトルが192次元である。"""
+        result = extract_embedding(voiced_audio_3s)
+        assert result.values.shape == (192,)
+
+    @requires_campplus_model
+    def test_output_dtype_is_float32(self, voiced_audio_3s: AudioData) -> None:
+        """出力の dtype が float32 である。"""
+        result = extract_embedding(voiced_audio_3s)
+        assert result.values.dtype == np.float32
+
+    @requires_campplus_model
+    def test_same_audio_produces_same_embedding(self, voiced_audio_3s: AudioData) -> None:
+        """同一音声から同一の埋め込みベクトルが得られる。"""
+        result1 = extract_embedding(voiced_audio_3s)
+        result2 = extract_embedding(voiced_audio_3s)
+        np.testing.assert_array_equal(result1.values, result2.values)
+
+    @requires_campplus_model
+    def test_result_type(self, voiced_audio_3s: AudioData) -> None:
+        """戻り値が Embedding である。"""
+        result = extract_embedding(voiced_audio_3s)
+        assert isinstance(result, Embedding)
+
+    @requires_campplus_model
+    def test_empty_audio_raises_error(self) -> None:
+        """空音声で EmbeddingExtractionError が発生する。"""
+        empty = AudioData(samples=np.array([], dtype=np.int16), sample_rate=16000)
+        with pytest.raises(EmbeddingExtractionError, match="空の音声データ"):
+            extract_embedding(empty)
+
+    @requires_campplus_model
+    def test_short_audio_raises_error(self) -> None:
+        """短すぎる音声で EmbeddingExtractionError が発生する。"""
+        # 50ms の極短音声 (100ms 未満)
+        short = AudioData(
+            samples=np.ones(800, dtype=np.int16),
+            sample_rate=16000,
+        )
+        with pytest.raises(EmbeddingExtractionError, match="短すぎて"):
+            extract_embedding(short)


### PR DESCRIPTION
## 概要

Issue #19 の設計に基づき、CAM++ (3D-Speaker) による話者埋め込みベクトル抽出モジュールを実装。

- `embedding_extractor.py`: エラー階層 (`EmbeddingExtractorError` → `EmbeddingModelLoadError`, `EmbeddingExtractionError`)、`Embedding` 型、`extract_embedding()` 関数
- sherpa_onnx の `SpeakerEmbeddingExtractor` API を使用し、既存の `vad.py` / `speech_recognizer.py` と同じパターンに従う
- 空音声・短すぎる音声 (100ms 未満) のバリデーション付き
- テスト7件 (モデル不要1件 + `@requires_campplus_model` 6件)