### PR TITLE
refactor: extract int16-to-float32 normalization into AudioData.samples_f32

### DIFF
--- a/src/voice_auth_engine/audio_preprocessor.py
+++ b/src/voice_auth_engine/audio_preprocessor.py
@@ -32,6 +32,11 @@ class AudioData(NamedTuple):
     samples: npt.NDArray[np.int16]  # 16kHz モノラル int16
     sample_rate: int  # 常に 16000
 
+    @property
+    def samples_f32(self) -> npt.NDArray[np.float32]:
+        """int16 サンプルを [-1.0, 1.0] の float32 に正規化して返す。"""
+        return self.samples.astype(np.float32) / 32768.0
+
 
 def load_audio(path: str | Path) -> AudioData:
     """音声ファイルを読み込み、16kHz モノラル int16 に変換する。

--- a/src/voice_auth_engine/embedding_extractor.py
+++ b/src/voice_auth_engine/embedding_extractor.py
@@ -70,11 +70,8 @@ def extract_embedding(
     if len(audio.samples) < min_samples:
         raise EmbeddingExtractionError("音声が短すぎて埋め込みを抽出できません")
 
-    # int16 → float32 正規化
-    samples_f32 = audio.samples.astype(np.float32) / 32768.0
-
     stream = extractor.create_stream()
-    stream.accept_waveform(audio.sample_rate, samples_f32)
+    stream.accept_waveform(audio.sample_rate, audio.samples_f32)
     stream.input_finished()
 
     if not extractor.is_ready(stream):

--- a/src/voice_auth_engine/speech_recognizer.py
+++ b/src/voice_auth_engine/speech_recognizer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import NamedTuple
 
-import numpy as np
 import sherpa_onnx
 
 from voice_auth_engine.audio_preprocessor import AudioData
@@ -81,11 +80,8 @@ def transcribe(
     except Exception as exc:
         raise RecognizerModelLoadError(f"SenseVoice モデルの読み込みに失敗しました: {exc}") from exc
 
-    # int16 → float32 正規化
-    samples_f32 = audio.samples.astype(np.float32) / 32768.0
-
     stream = recognizer.create_stream()
-    stream.accept_waveform(audio.sample_rate, samples_f32)
+    stream.accept_waveform(audio.sample_rate, audio.samples_f32)
     recognizer.decode_stream(stream)
 
     return TranscriptionResult(text=stream.result.text.strip())

--- a/src/voice_auth_engine/vad.py
+++ b/src/voice_auth_engine/vad.py
@@ -84,10 +84,7 @@ def detect_speech(
     if len(audio.samples) == 0:
         return SpeechSegments(segments=[], audio=audio)
 
-    # int16 → float32 正規化 (Silero VAD は [-1, 1] の float32 を期待)
-    samples_f32 = audio.samples.astype(np.float32) / 32768.0
-
-    vad.accept_waveform(samples_f32)
+    vad.accept_waveform(audio.samples_f32)
     vad.flush()
 
     segments: list[SpeechSegment] = []

--- a/tests/test_audio_preprocessor.py
+++ b/tests/test_audio_preprocessor.py
@@ -8,6 +8,7 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.audio_preprocessor import (
+    AudioData,
     AudioDecodeError,
     UnsupportedFormatError,
     load_audio,
@@ -97,3 +98,12 @@ class TestLoadAudio:
         upper.write_bytes(src.read_bytes())
         result = load_audio(upper)
         assert len(result.samples) > 0
+
+
+class TestAudioData:
+    """AudioData の samples_f32 プロパティのテスト。"""
+
+    def test_samples_f32_dtype(self) -> None:
+        """float32 の配列を返す。"""
+        audio = AudioData(samples=np.array([0, 16384, -16384], dtype=np.int16), sample_rate=16000)
+        assert audio.samples_f32.dtype == np.float32


### PR DESCRIPTION
## 概要

`vad.py`・`speech_recognizer.py`・`embedding_extractor.py` に重複していた int16→float32 正規化処理を `AudioData.samples_f32` プロパティとして共通化。

- `AudioData` に `samples_f32` プロパティを追加
- 3モジュールの正規化コードを `audio.samples_f32` 呼び出しに置換
- `speech_recognizer.py` から不要になった `import numpy` を削除
- `test_audio_preprocessor.py` に `TestAudioData` テストクラスを追加