### PR TITLE
refactor: rename vad module to speech_detector

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -12,20 +12,20 @@ from voice_auth_engine.embedding_extractor import (
     EmbeddingModelLoadError,
     extract_embedding,
 )
+from voice_auth_engine.speech_detector import (
+    SpeechDetectorError,
+    SpeechDetectorModelLoadError,
+    SpeechSegment,
+    SpeechSegments,
+    detect_speech,
+    extract_speech,
+)
 from voice_auth_engine.speech_recognizer import (
     RecognitionError,
     RecognizerModelLoadError,
     SpeechRecognizerError,
     TranscriptionResult,
     transcribe,
-)
-from voice_auth_engine.vad import (
-    SpeechSegment,
-    SpeechSegments,
-    VadError,
-    VadModelLoadError,
-    detect_speech,
-    extract_speech,
 )
 
 __all__ = [
@@ -43,8 +43,8 @@ __all__ = [
     "SpeechSegments",
     "TranscriptionResult",
     "UnsupportedFormatError",
-    "VadError",
-    "VadModelLoadError",
+    "SpeechDetectorError",
+    "SpeechDetectorModelLoadError",
     "detect_speech",
     "extract_embedding",
     "extract_speech",

--- a/src/voice_auth_engine/speech_detector.py
+++ b/src/voice_auth_engine/speech_detector.py
@@ -12,12 +12,12 @@ from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.model_config import silero_vad_config
 
 
-class VadError(Exception):
-    """VAD 処理の基底例外。"""
+class SpeechDetectorError(Exception):
+    """音声区間検出の基底例外。"""
 
 
-class VadModelLoadError(VadError):
-    """VAD モデルの読み込み失敗。"""
+class SpeechDetectorModelLoadError(SpeechDetectorError):
+    """音声区間検出モデルの読み込み失敗。"""
 
 
 class SpeechSegment(NamedTuple):
@@ -57,14 +57,14 @@ def detect_speech(
         SpeechSegments: 検出された発話区間のリストと元の音声データ。
 
     Raises:
-        VadModelLoadError: モデルの読み込みに失敗した場合。
+        SpeechDetectorModelLoadError: モデルの読み込みに失敗した場合。
     """
     if model_path is None:
         model_path = silero_vad_config.path
     model_path = Path(model_path)
 
     if not model_path.exists():
-        raise VadModelLoadError(f"VAD モデルファイルが見つかりません: {model_path}")
+        raise SpeechDetectorModelLoadError(f"VAD モデルファイルが見つかりません: {model_path}")
 
     config = sherpa_onnx.VadModelConfig(
         silero_vad=sherpa_onnx.SileroVadModelConfig(
@@ -79,7 +79,7 @@ def detect_speech(
     try:
         vad = sherpa_onnx.VoiceActivityDetector(config)
     except Exception as exc:
-        raise VadModelLoadError(f"VAD モデルの読み込みに失敗しました: {exc}") from exc
+        raise SpeechDetectorModelLoadError(f"VAD モデルの読み込みに失敗しました: {exc}") from exc
 
     if len(audio.samples) == 0:
         return SpeechSegments(segments=[], audio=audio)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ from .audio_factory import (
     make_audio_data,
 )
 
-requires_vad_model = pytest.mark.skipif(
+requires_silero_vad_model = pytest.mark.skipif(
     not silero_vad_config.path.exists(), reason="Silero VAD model not found"
 )
 

--- a/tests/test_speech_detector.py
+++ b/tests/test_speech_detector.py
@@ -1,4 +1,4 @@
-"""VAD モジュールのテスト。"""
+"""speech_detector モジュールのテスト。"""
 
 from __future__ import annotations
 
@@ -6,21 +6,21 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.audio_preprocessor import AudioData
-from voice_auth_engine.vad import (
+from voice_auth_engine.speech_detector import (
+    SpeechDetectorModelLoadError,
     SpeechSegment,
     SpeechSegments,
-    VadModelLoadError,
     detect_speech,
     extract_speech,
 )
 
 from .audio_factory import generate_silence_samples, generate_voiced_samples, make_audio_data
-from .conftest import requires_vad_model
+from .conftest import requires_silero_vad_model
 
 SAMPLE_RATE = 16000
 
 
-@requires_vad_model
+@requires_silero_vad_model
 class TestDetectSpeech:
     """detect_speech 関数のテスト。"""
 
@@ -80,12 +80,12 @@ class TestDetectSpeech:
             assert seg.end_sample <= len(voiced_audio.samples)
 
     def test_model_path_not_found(self, voiced_audio: AudioData) -> None:
-        """不正パスで VadModelLoadError。"""
-        with pytest.raises(VadModelLoadError):
+        """不正パスで SpeechDetectorModelLoadError。"""
+        with pytest.raises(SpeechDetectorModelLoadError):
             detect_speech(voiced_audio, model_path="/nonexistent/model.onnx")
 
 
-@requires_vad_model
+@requires_silero_vad_model
 class TestExtractSpeech:
     """extract_speech 関数のテスト。"""
 

--- a/tests/test_speech_detector_integration.py
+++ b/tests/test_speech_detector_integration.py
@@ -1,4 +1,4 @@
-"""VAD モジュールの統合テスト（実音声）。"""
+"""speech_detector モジュールの統合テスト（実音声）。"""
 
 from __future__ import annotations
 
@@ -8,9 +8,9 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.audio_preprocessor import AudioData, load_audio
-from voice_auth_engine.vad import detect_speech, extract_speech
+from voice_auth_engine.speech_detector import detect_speech, extract_speech
 
-from .conftest import requires_vad_model
+from .conftest import requires_silero_vad_model
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SAMPLE_RATE = 16000
@@ -34,7 +34,7 @@ def digit_single_short() -> AudioData:
     return load_audio(FIXTURES_DIR / "digit_single_short.mp3")
 
 
-@requires_vad_model
+@requires_silero_vad_model
 class TestDetectSpeechWithRealAudio:
     """実音声を使った detect_speech のテスト。"""
 
@@ -92,7 +92,7 @@ class TestDetectSpeechWithRealAudio:
         assert result.segments[0].start_sec >= 1.5
 
 
-@requires_vad_model
+@requires_silero_vad_model
 class TestExtractSpeechWithRealAudio:
     """実音声を使った extract_speech のテスト。"""
 


### PR DESCRIPTION
## 概要

モジュール命名の一貫性を改善。`speech_recognizer`・`embedding_extractor` と揃えるため、略称だった `vad` を `speech_detector` にリネーム。

- `vad.py` → `speech_detector.py`
- `test_vad.py` → `test_speech_detector.py`
- `test_vad_integration.py` → `test_speech_detector_integration.py`
- `VadError` → `SpeechDetectorError`、`VadModelLoadError` → `SpeechDetectorModelLoadError`
- テストマーカーを `requires_silero_vad_model` に統一（モデル名ベース）