### PR TITLE
feat: add load_audio_bytes to decode audio from bytes without disk I/O

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -4,6 +4,7 @@ from voice_auth_engine.audio_preprocessor import (
     AudioPreprocessError,
     UnsupportedFormatError,
     load_audio,
+    load_audio_bytes,
 )
 from voice_auth_engine.embedding_extractor import (
     Embedding,
@@ -78,6 +79,7 @@ __all__ = [
     "extract_embedding",
     "extract_speech",
     "load_audio",
+    "load_audio_bytes",
     "transcribe",
     "validate_passphrase",
 ]

--- a/tests/test_audio_preprocessor.py
+++ b/tests/test_audio_preprocessor.py
@@ -12,6 +12,7 @@ from voice_auth_engine.audio_preprocessor import (
     AudioDecodeError,
     UnsupportedFormatError,
     load_audio,
+    load_audio_bytes,
 )
 
 from .audio_factory import generate_audio_file
@@ -98,6 +99,35 @@ class TestLoadAudio:
         upper.write_bytes(src.read_bytes())
         result = load_audio(upper)
         assert len(result.samples) > 0
+
+
+class TestLoadAudioBytes:
+    """load_audio_bytes 関数のテスト。"""
+
+    def test_decodes_wav_bytes(self, wav_16k_mono: Path) -> None:
+        """WAV bytes をデコードできる。"""
+        data = wav_16k_mono.read_bytes()
+        result = load_audio_bytes(data)
+        assert result.sample_rate == 16000
+        assert result.samples.dtype == np.int16
+        assert len(result.samples) > 0
+
+    def test_decodes_with_explicit_format(self, wav_16k_mono: Path) -> None:
+        """format 明示指定でデコードできる。"""
+        data = wav_16k_mono.read_bytes()
+        result = load_audio_bytes(data, format="wav")
+        assert result.sample_rate == 16000
+        assert len(result.samples) > 0
+
+    def test_raises_on_empty_bytes(self) -> None:
+        """空 bytes で AudioDecodeError。"""
+        with pytest.raises(AudioDecodeError):
+            load_audio_bytes(b"")
+
+    def test_raises_on_invalid_bytes(self) -> None:
+        """不正 bytes で AudioDecodeError。"""
+        with pytest.raises(AudioDecodeError):
+            load_audio_bytes(b"not a real audio file")
 
 
 class TestAudioData:


### PR DESCRIPTION
## 概要
REST API / WebSocket から受け取った bytes を直接デコードできる `load_audio_bytes` を追加。
`io.BytesIO` 経由で PyAV に渡すことでディスク I/O なしにデコードする。
`load_audio` も内部で `load_audio_bytes` に委譲する形にリファクタ。