### PR TITLE
feat: add to_bytes/from_bytes serialization to Embedding (#30)

### DIFF
--- a/src/voice_auth_engine/embedding_extractor.py
+++ b/src/voice_auth_engine/embedding_extractor.py
@@ -30,6 +30,15 @@ class Embedding(NamedTuple):
 
     values: npt.NDArray[np.float32]
 
+    def to_bytes(self) -> bytes:
+        """埋め込みベクトルをバイト列にシリアライズする。"""
+        return self.values.tobytes()
+
+    @staticmethod
+    def from_bytes(data: bytes) -> Embedding:
+        """バイト列から埋め込みベクトルを復元する。"""
+        return Embedding(values=np.frombuffer(data, dtype=np.float32).copy())
+
 
 def extract_embedding(
     audio: AudioData,


### PR DESCRIPTION
## 概要

`Embedding` に `to_bytes()` / `from_bytes()` メソッドを追加し、埋め込みベクトルのバイト列シリアライズ・デシリアライズを可能にする。これにより DB 保存・復元が容易になる。

- `to_bytes()`: float32 配列をバイト列に変換
- `from_bytes()`: バイト列から `Embedding` を復元（`.copy()` で書き込み可能な配列を保証）
- テスト追加: roundtrip, dtype 保持, 空バイト, writable の 4 ケース

🤖 Generated with [Claude Code](https://claude.com/claude-code)