### PR TITLE
refactor: rename load_audio_bytes to decode_audio

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -3,8 +3,8 @@ from voice_auth_engine.audio_preprocessor import (
     AudioDecodeError,
     AudioPreprocessError,
     UnsupportedFormatError,
+    decode_audio,
     load_audio,
-    load_audio_bytes,
 )
 from voice_auth_engine.embedding_extractor import (
     Embedding,
@@ -79,7 +79,7 @@ __all__ = [
     "extract_embedding",
     "extract_speech",
     "load_audio",
-    "load_audio_bytes",
+    "decode_audio",
     "transcribe",
     "validate_passphrase",
 ]

--- a/src/voice_auth_engine/audio_preprocessor.py
+++ b/src/voice_auth_engine/audio_preprocessor.py
@@ -59,7 +59,7 @@ def load_audio(audio: AudioInput) -> AudioData:
         AudioDecodeError: デコードに失敗した場合。
     """
     if isinstance(audio, bytes):
-        return load_audio_bytes(audio)
+        return decode_audio(audio)
     if isinstance(audio, (str, Path)):
         path = Path(audio)
         if not path.exists():
@@ -67,11 +67,11 @@ def load_audio(audio: AudioInput) -> AudioData:
         ext = path.suffix.lower()
         if ext not in SUPPORTED_EXTENSIONS:
             raise UnsupportedFormatError(f"非対応の音声フォーマットです: {ext}")
-        return load_audio_bytes(path.read_bytes())
+        return decode_audio(path.read_bytes())
     raise TypeError(f"未対応の入力型です: {type(audio)}")
 
 
-def load_audio_bytes(data: bytes, *, format: str | None = None) -> AudioData:
+def decode_audio(data: bytes, *, format: str | None = None) -> AudioData:
     """bytes から音声をデコードし、16kHz モノラル int16 に変換する。
 
     Args:

--- a/tests/test_audio_preprocessor.py
+++ b/tests/test_audio_preprocessor.py
@@ -11,8 +11,8 @@ from voice_auth_engine.audio_preprocessor import (
     AudioData,
     AudioDecodeError,
     UnsupportedFormatError,
+    decode_audio,
     load_audio,
-    load_audio_bytes,
 )
 
 from .audio_factory import generate_audio_file
@@ -113,13 +113,13 @@ class TestLoadAudio:
             load_audio(12345)  # type: ignore[arg-type]
 
 
-class TestLoadAudioBytes:
-    """load_audio_bytes 関数のテスト。"""
+class TestDecodeAudio:
+    """decode_audio 関数のテスト。"""
 
     def test_decodes_wav_bytes(self, wav_16k_mono: Path) -> None:
         """WAV bytes をデコードできる。"""
         data = wav_16k_mono.read_bytes()
-        result = load_audio_bytes(data)
+        result = decode_audio(data)
         assert result.sample_rate == 16000
         assert result.samples.dtype == np.int16
         assert len(result.samples) > 0
@@ -127,19 +127,19 @@ class TestLoadAudioBytes:
     def test_decodes_with_explicit_format(self, wav_16k_mono: Path) -> None:
         """format 明示指定でデコードできる。"""
         data = wav_16k_mono.read_bytes()
-        result = load_audio_bytes(data, format="wav")
+        result = decode_audio(data, format="wav")
         assert result.sample_rate == 16000
         assert len(result.samples) > 0
 
     def test_raises_on_empty_bytes(self) -> None:
         """空 bytes で AudioDecodeError。"""
         with pytest.raises(AudioDecodeError):
-            load_audio_bytes(b"")
+            decode_audio(b"")
 
     def test_raises_on_invalid_bytes(self) -> None:
         """不正 bytes で AudioDecodeError。"""
         with pytest.raises(AudioDecodeError):
-            load_audio_bytes(b"not a real audio file")
+            decode_audio(b"not a real audio file")
 
 
 class TestAudioData:


### PR DESCRIPTION
## 概要

`load_audio_bytes` を `decode_audio` にリネーム。
関数の実際の責務（バイト列のデコード）をより正確に反映する命名に変更。