### PR TITLE
refactor: use audio_validator for extension validation in load_audio

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -2,7 +2,6 @@ from voice_auth_engine.audio_preprocessor import (
     AudioData,
     AudioDecodeError,
     AudioPreprocessError,
-    UnsupportedFormatError,
     decode_audio,
     load_audio,
 )
@@ -86,7 +85,6 @@ __all__ = [
     "SUPPORTED_EXTENSIONS",
     "TranscriptionResult",
     "UnsupportedExtensionError",
-    "UnsupportedFormatError",
     "VerificationResult",
     "analyze_passphrase",
     "check_speech_duration",

--- a/src/voice_auth_engine/audio_preprocessor.py
+++ b/src/voice_auth_engine/audio_preprocessor.py
@@ -10,17 +10,13 @@ import av
 import numpy as np
 import numpy.typing as npt
 
-TARGET_SAMPLE_RATE = 16000
+from voice_auth_engine.audio_validator import validate_extension
 
-SUPPORTED_EXTENSIONS = frozenset({".wav", ".mp3", ".ogg", ".webm", ".aac", ".flac", ".m4a"})
+TARGET_SAMPLE_RATE = 16000
 
 
 class AudioPreprocessError(Exception):
     """音声前処理の基底例外。"""
-
-
-class UnsupportedFormatError(AudioPreprocessError):
-    """非対応の音声フォーマット。"""
 
 
 class AudioDecodeError(AudioPreprocessError):
@@ -55,7 +51,7 @@ def load_audio(audio: AudioInput) -> AudioData:
     Raises:
         TypeError: 未対応の入力型の場合。
         FileNotFoundError: ファイルが存在しない場合。
-        UnsupportedFormatError: 非対応の拡張子の場合。
+        UnsupportedExtensionError: 非対応の拡張子の場合。
         AudioDecodeError: デコードに失敗した場合。
     """
     if isinstance(audio, bytes):
@@ -64,9 +60,7 @@ def load_audio(audio: AudioInput) -> AudioData:
         path = Path(audio)
         if not path.exists():
             raise FileNotFoundError(f"音声ファイルが見つかりません: {path}")
-        ext = path.suffix.lower()
-        if ext not in SUPPORTED_EXTENSIONS:
-            raise UnsupportedFormatError(f"非対応の音声フォーマットです: {ext}")
+        validate_extension(path)
         return decode_audio(path.read_bytes())
     raise TypeError(f"未対応の入力型です: {type(audio)}")
 

--- a/src/voice_auth_engine/audio_validator.py
+++ b/src/voice_auth_engine/audio_validator.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from voice_auth_engine.audio_preprocessor import AudioData
+if TYPE_CHECKING:
+    from voice_auth_engine.audio_preprocessor import AudioData
 
 SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
     {".wav", ".mp3", ".ogg", ".webm", ".aac", ".flac", ".m4a"}

--- a/tests/test_audio_preprocessor.py
+++ b/tests/test_audio_preprocessor.py
@@ -10,10 +10,10 @@ import pytest
 from voice_auth_engine.audio_preprocessor import (
     AudioData,
     AudioDecodeError,
-    UnsupportedFormatError,
     decode_audio,
     load_audio,
 )
+from voice_auth_engine.audio_validator import UnsupportedExtensionError
 
 from .audio_factory import generate_audio_file
 
@@ -74,10 +74,10 @@ class TestLoadAudio:
             load_audio(tmp_audio_dir / "nonexistent.wav")
 
     def test_raises_unsupported_format(self, tmp_audio_dir: Path) -> None:
-        """非対応拡張子で UnsupportedFormatError。"""
+        """非対応拡張子で UnsupportedExtensionError。"""
         txt_file = tmp_audio_dir / "test.txt"
         txt_file.write_text("not audio")
-        with pytest.raises(UnsupportedFormatError):
+        with pytest.raises(UnsupportedExtensionError):
             load_audio(txt_file)
 
     def test_raises_audio_decode_error_for_corrupt(self, tmp_audio_dir: Path) -> None:


### PR DESCRIPTION
## 概要

`load_audio` の拡張子バリデーションを `audio_validator.validate_extension()` に委譲するリファクタ。

- `audio_preprocessor` からインラインの拡張子チェック・`SUPPORTED_EXTENSIONS`・`UnsupportedFormatError` を削除
- `audio_validator` の `AudioData` import を `TYPE_CHECKING` に移動し循環インポートを解消
- テストの期待例外を `UnsupportedExtensionError` に更新