### PR TITLE
feat: add normalized_edit_distance function (#40)

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -23,7 +23,7 @@ from voice_auth_engine.embedding_extractor import (
     EmbeddingModelLoadError,
     extract_embedding,
 )
-from voice_auth_engine.math import cosine_similarity
+from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 from voice_auth_engine.passphrase_auth import (
     PassphraseAuth,
     PassphraseAuthEnroller,
@@ -87,6 +87,7 @@ __all__ = [
     "UnsupportedExtensionError",
     "analyze_passphrase",
     "cosine_similarity",
+    "normalized_edit_distance",
     "detect_speech",
     "extract_embedding",
     "extract_speech",

--- a/src/voice_auth_engine/math.py
+++ b/src/voice_auth_engine/math.py
@@ -2,8 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+from typing import TypeVar
+
 import numpy as np
 import numpy.typing as npt
+
+T = TypeVar("T")
 
 
 def cosine_similarity(
@@ -25,3 +30,40 @@ def cosine_similarity(
     if norm_a == 0 or norm_b == 0:
         return 0.0
     return float(np.dot(a, b) / (norm_a * norm_b))
+
+
+def normalized_edit_distance(a: Sequence[T], b: Sequence[T]) -> float:
+    """2つの系列の正規化編集距離を計算する。
+
+    レーベンシュタイン距離を max(len(a), len(b)) で正規化する。
+    Wagner-Fischer DP アルゴリズム（省メモリ 1行DP）で実装。
+
+    Args:
+        a: 系列 a。
+        b: 系列 b。
+
+    Returns:
+        正規化編集距離 [0.0, 1.0]。0.0 = 完全一致。両方空なら 0.0。
+    """
+    len_a, len_b = len(a), len(b)
+    if len_a == 0 and len_b == 0:
+        return 0.0
+
+    # 短い方を row にして省メモリ化
+    if len_a > len_b:
+        a, b = b, a
+        len_a, len_b = len_b, len_a
+
+    prev = list(range(len_a + 1))
+    for j in range(1, len_b + 1):
+        curr = [j] + [0] * len_a
+        for i in range(1, len_a + 1):
+            cost = 0 if a[i - 1] == b[j - 1] else 1
+            curr[i] = min(
+                curr[i - 1] + 1,  # 挿入
+                prev[i] + 1,  # 削除
+                prev[i - 1] + cost,  # 置換
+            )
+        prev = curr
+
+    return prev[len_a] / max(len_a, len_b)

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -3,7 +3,7 @@
 import numpy as np
 import pytest
 
-from voice_auth_engine.math import cosine_similarity
+from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 
 
 class TestCosineSimilarity:
@@ -32,3 +32,33 @@ class TestCosineSimilarity:
         z = np.zeros(3, dtype=np.float32)
         assert cosine_similarity(a, z) == pytest.approx(0.0)
         assert cosine_similarity(z, a) == pytest.approx(0.0)
+
+
+class TestNormalizedEditDistance:
+    """normalized_edit_distance のテスト。"""
+
+    def test_identical_sequences(self) -> None:
+        """同一系列 → 0.0。"""
+        seq = ["a", "b", "c"]
+        assert normalized_edit_distance(seq, seq) == pytest.approx(0.0)
+
+    def test_both_empty(self) -> None:
+        """両方空 → 0.0。"""
+        assert normalized_edit_distance([], []) == pytest.approx(0.0)
+
+    def test_one_empty(self) -> None:
+        """片方空 → 1.0。"""
+        assert normalized_edit_distance(["a", "b"], []) == pytest.approx(1.0)
+        assert normalized_edit_distance([], ["a", "b"]) == pytest.approx(1.0)
+
+    def test_partial_match(self) -> None:
+        """部分一致 → 1/3。"""
+        a = ["a", "b", "c"]
+        b = ["a", "b", "d"]
+        assert normalized_edit_distance(a, b) == pytest.approx(1 / 3)
+
+    def test_completely_different(self) -> None:
+        """完全不一致 → 1.0。"""
+        a = ["a", "b", "c"]
+        b = ["x", "y", "z"]
+        assert normalized_edit_distance(a, b) == pytest.approx(1.0)


### PR DESCRIPTION
## 概要

音素列比較の基盤となる正規化編集距離（Normalized Edit Distance）関数を追加する。

- `math.py` に `normalized_edit_distance(a, b)` を追加（Wagner-Fischer 省メモリ1行DP）
- レーベンシュタイン距離を `max(len(a), len(b))` で正規化し `[0.0, 1.0]` を返す
- テスト5件を追加（同一 / 両方空 / 片方空 / 部分一致 / 完全不一致）

Closes #40