### PR TITLE
feat: add pairwise_distances and select_medoid to math module

### DIFF
--- a/src/voice_auth_engine/math.py
+++ b/src/voice_auth_engine/math.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from typing import TypeVar
 
 import numpy as np
@@ -67,3 +67,37 @@ def normalized_edit_distance(a: Sequence[T], b: Sequence[T]) -> float:
         prev = curr
 
     return prev[len_a] / max(len_a, len_b)
+
+
+def pairwise_distances(
+    sequences: Sequence[Sequence[T]],
+    distance_fn: Callable[[Sequence[T], Sequence[T]], float] = normalized_edit_distance,
+) -> list[list[float]]:
+    """全ペア間の距離行列を計算する。
+
+    Returns:
+        n×n の対称行列。distances[i][j] は sequences[i] と sequences[j] の距離。
+    """
+    n = len(sequences)
+    distances = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = distance_fn(sequences[i], sequences[j])
+            distances[i][j] = d
+            distances[j][i] = d
+    return distances
+
+
+def select_medoid(distances: Sequence[Sequence[float]]) -> int:
+    """距離行列からメドイド（他の全要素との距離合計が最小の要素）のインデックスを返す。
+
+    同スコアの場合は最小インデックスを採用。
+    """
+    min_index = 0
+    min_sum = float("inf")
+    for i, row in enumerate(distances):
+        total = sum(row)
+        if total < min_sum:
+            min_sum = total
+            min_index = i
+    return min_index

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -3,7 +3,12 @@
 import numpy as np
 import pytest
 
-from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
+from voice_auth_engine.math import (
+    cosine_similarity,
+    normalized_edit_distance,
+    pairwise_distances,
+    select_medoid,
+)
 
 
 class TestCosineSimilarity:
@@ -62,3 +67,61 @@ class TestNormalizedEditDistance:
         a = ["a", "b", "c"]
         b = ["x", "y", "z"]
         assert normalized_edit_distance(a, b) == pytest.approx(1.0)
+
+
+class TestPairwiseDistances:
+    """pairwise_distances のテスト。"""
+
+    def test_normal(self) -> None:
+        """正常系: 距離行列が対称であること。"""
+        seqs = [["a", "b", "c"], ["a", "b", "d"], ["x", "y", "z"]]
+        result = pairwise_distances(seqs)
+
+        assert len(result) == 3
+        # 対角は 0
+        for i in range(3):
+            assert result[i][i] == pytest.approx(0.0)
+        # 対称
+        for i in range(3):
+            for j in range(3):
+                assert result[i][j] == pytest.approx(result[j][i])
+        # 具体値
+        assert result[0][1] == pytest.approx(1 / 3)
+        assert result[0][2] == pytest.approx(1.0)
+
+    def test_single_element(self) -> None:
+        """単一要素 → 1×1 のゼロ行列。"""
+        result = pairwise_distances([["a", "b"]])
+        assert result == [[0.0]]
+
+    def test_empty_list(self) -> None:
+        """空リスト → 空行列。"""
+        result = pairwise_distances([])
+        assert result == []
+
+
+class TestSelectMedoid:
+    """select_medoid のテスト。"""
+
+    def test_normal(self) -> None:
+        """正常系: 距離合計が最小の要素を返す。"""
+        # idx0: 0+1+3=4, idx1: 1+0+1=2, idx2: 3+1+0=4
+        distances = [
+            [0.0, 1.0, 3.0],
+            [1.0, 0.0, 1.0],
+            [3.0, 1.0, 0.0],
+        ]
+        assert select_medoid(distances) == 1
+
+    def test_tie_returns_first(self) -> None:
+        """同スコア時は最小インデックスを返す。"""
+        # idx0: 0+1=1, idx1: 1+0=1
+        distances = [
+            [0.0, 1.0],
+            [1.0, 0.0],
+        ]
+        assert select_medoid(distances) == 0
+
+    def test_single_element(self) -> None:
+        """単一要素 → 0。"""
+        assert select_medoid([[0.0]]) == 0


### PR DESCRIPTION
## 概要

Closes #44

`math.py` に汎用的な距離計算関数を追加する。これらは #41（登録パイプラインの音素収集・検証）で使用する。

- `pairwise_distances`: 全ペア間の距離行列を計算（デフォルトで `normalized_edit_distance` を使用）
- `select_medoid`: 距離行列からメドイド（距離合計が最小の要素）のインデックスを返す
- テストを追加（正常系、境界値、同スコア時の挙動）