### PR TITLE
feat: add enrollment pipeline phoneme collection and consistency validation (#41)

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -25,10 +25,13 @@ from voice_auth_engine.embedding_extractor import (
 )
 from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 from voice_auth_engine.passphrase_auth import (
+    EnrollmentResult,
     PassphraseAuth,
     PassphraseAuthEnroller,
     PassphraseAuthError,
     PassphraseAuthVerifier,
+    PassphraseEnrollmentError,
+    PassphraseExtractionResult,
 )
 from voice_auth_engine.passphrase_validator import (
     EmptyPassphraseError,
@@ -67,12 +70,15 @@ __all__ = [
     "EmbeddingModelLoadError",
     "EmptyAudioError",
     "EmptyPassphraseError",
+    "EnrollmentResult",
     "InsufficientDurationError",
     "InsufficientPhonemeError",
     "PassphraseAuth",
     "PassphraseAuthError",
     "PassphraseAuthEnroller",
     "PassphraseAuthVerifier",
+    "PassphraseEnrollmentError",
+    "PassphraseExtractionResult",
     "PassphraseInfo",
     "PassphraseValidationError",
     "RecognitionError",

--- a/tests/test_passphrase_auth.py
+++ b/tests/test_passphrase_auth.py
@@ -11,10 +11,13 @@ from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.audio_validator import EmptyAudioError
 from voice_auth_engine.embedding_extractor import Embedding
 from voice_auth_engine.passphrase_auth import (
+    EnrollmentResult,
     PassphraseAuth,
     PassphraseAuthEnroller,
     PassphraseAuthVerifier,
+    PassphraseEnrollmentError,
 )
+from voice_auth_engine.passphrase_validator import PassphraseInfo
 
 from .audio_factory import make_audio, make_embedding, make_segments
 
@@ -79,8 +82,8 @@ class TestPassphraseAuthEnroller:
 
         enroller = auth.create_enroller()
         enroller.add_sample(audio)
-        embedding = enroller.enroll()
-        np.testing.assert_array_equal(embedding.values, [1.0, 0.0, 0.0])
+        result = enroller.enroll()
+        np.testing.assert_array_equal(result.embedding.values, [1.0, 0.0, 0.0])
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
@@ -107,8 +110,8 @@ class TestPassphraseAuthEnroller:
         enroller = auth.create_enroller()
         enroller.add_sample(audio)
         enroller.add_sample(audio)
-        embedding = enroller.enroll()
-        np.testing.assert_array_almost_equal(embedding.values, [0.5, 0.5, 0.0])
+        result = enroller.enroll()
+        np.testing.assert_array_almost_equal(result.embedding.values, [0.5, 0.5, 0.0])
 
     def test_enroll_no_samples_raises(self, auth: PassphraseAuth) -> None:
         """サンプル未蓄積で ValueError。"""
@@ -159,8 +162,9 @@ class TestPassphraseAuthEnroller:
 
         enroller = auth.create_enroller()
         enroller.add_sample(audio)
-        embedding = enroller.enroll()
-        assert isinstance(embedding, Embedding)
+        result = enroller.enroll()
+        assert isinstance(result, EnrollmentResult)
+        assert isinstance(result.embedding, Embedding)
 
     def test_create_enroller_returns_correct_type(self, auth: PassphraseAuth) -> None:
         """create_enroller が PassphraseAuthEnroller を返す。"""
@@ -249,3 +253,186 @@ class TestPassphraseAuthVerifier:
         enrolled = make_embedding([1.0, 0.0, 0.0])
         verifier = auth.create_verifier(enrolled)
         assert isinstance(verifier, PassphraseAuthVerifier)
+
+
+class TestPassphraseAuthPhonemes:
+    """音素収集・メドイド選択・整合性チェックのテスト。"""
+
+    @pytest.fixture
+    def auth_with_phonemes(self) -> PassphraseAuth:
+        """phoneme_threshold 有効の PassphraseAuth。"""
+        return PassphraseAuth(
+            threshold=0.5,
+            min_speech_seconds=0.1,
+            min_unique_phonemes=None,
+            phoneme_threshold=0.3,
+        )
+
+    def _setup_mocks(
+        self,
+        mock_load: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_extract_emb: MagicMock,
+        mock_transcribe: MagicMock,
+        mock_analyze: MagicMock,
+        *,
+        phoneme_lists: list[list[str]],
+    ) -> AudioData:
+        """共通モック設定。"""
+        audio = make_audio(1.0)
+        mock_load.return_value = audio
+        mock_detect.return_value = make_segments(audio)
+        mock_extract_sp.return_value = audio
+        mock_extract_emb.side_effect = [make_embedding([1.0, 0.0, 0.0]) for _ in phoneme_lists]
+        mock_transcribe.side_effect = [
+            MagicMock(text=f"text{i}") for i in range(len(phoneme_lists))
+        ]
+        mock_analyze.side_effect = [
+            PassphraseInfo(
+                text=f"text{i}",
+                phonemes=p,
+                unique_phonemes=set(p),
+                unique_count=len(set(p)),
+            )
+            for i, p in enumerate(phoneme_lists)
+        ]
+        return audio
+
+    @patch("voice_auth_engine.passphrase_auth.analyze_passphrase")
+    @patch("voice_auth_engine.passphrase_auth.transcribe")
+    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.passphrase_auth.extract_speech")
+    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    def test_extract_passphrase_returns_phonemes(
+        self,
+        mock_load: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_extract_emb: MagicMock,
+        mock_transcribe: MagicMock,
+        mock_analyze: MagicMock,
+        auth_with_phonemes: PassphraseAuth,
+    ) -> None:
+        """extract_passphrase が音素列を含む結果を返す。"""
+        phonemes = ["a", "i", "u", "e", "o"]
+        audio = self._setup_mocks(
+            mock_load,
+            mock_detect,
+            mock_extract_sp,
+            mock_extract_emb,
+            mock_transcribe,
+            mock_analyze,
+            phoneme_lists=[phonemes],
+        )
+        result = auth_with_phonemes.extract_passphrase(audio)
+        assert result.phonemes == phonemes
+        assert isinstance(result.embedding, Embedding)
+
+    @patch("voice_auth_engine.passphrase_auth.analyze_passphrase")
+    @patch("voice_auth_engine.passphrase_auth.transcribe")
+    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.passphrase_auth.extract_speech")
+    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    def test_enroll_selects_medoid_phonemes(
+        self,
+        mock_load: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_extract_emb: MagicMock,
+        mock_transcribe: MagicMock,
+        mock_analyze: MagicMock,
+        auth_with_phonemes: PassphraseAuth,
+    ) -> None:
+        """enroll() がメドイドで選ばれた基準音素列を返す。"""
+        # サンプル0,1は同一、サンプル2は1箇所異なる
+        # d(0,1)=0.0, d(0,2)=0.2, d(1,2)=0.2
+        # メドイド: サンプル0（距離合計0.2、同率のサンプル1より先頭）
+        phoneme_lists = [
+            ["a", "i", "u", "e", "o"],
+            ["a", "i", "u", "e", "o"],
+            ["a", "i", "u", "e", "a"],
+        ]
+        audio = self._setup_mocks(
+            mock_load,
+            mock_detect,
+            mock_extract_sp,
+            mock_extract_emb,
+            mock_transcribe,
+            mock_analyze,
+            phoneme_lists=phoneme_lists,
+        )
+        enroller = auth_with_phonemes.create_enroller()
+        for _ in range(3):
+            enroller.add_sample(audio)
+        result = enroller.enroll()
+        assert isinstance(result, EnrollmentResult)
+        assert result.phonemes == ["a", "i", "u", "e", "o"]
+
+    @patch("voice_auth_engine.passphrase_auth.analyze_passphrase")
+    @patch("voice_auth_engine.passphrase_auth.transcribe")
+    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.passphrase_auth.extract_speech")
+    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    def test_enroll_raises_on_inconsistent_phonemes(
+        self,
+        mock_load: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_extract_emb: MagicMock,
+        mock_transcribe: MagicMock,
+        mock_analyze: MagicMock,
+    ) -> None:
+        """音素列の距離が閾値を超えると PassphraseEnrollmentError。"""
+        auth = PassphraseAuth(
+            threshold=0.5,
+            min_speech_seconds=0.1,
+            min_unique_phonemes=None,
+            phoneme_threshold=0.1,  # 厳しい閾値
+        )
+        # d(0,1) = 0.4 > 0.1 → エラー
+        phoneme_lists = [
+            ["a", "i", "u", "e", "o"],
+            ["k", "a", "u", "e", "o"],
+        ]
+        audio = self._setup_mocks(
+            mock_load,
+            mock_detect,
+            mock_extract_sp,
+            mock_extract_emb,
+            mock_transcribe,
+            mock_analyze,
+            phoneme_lists=phoneme_lists,
+        )
+        enroller = auth.create_enroller()
+        enroller.add_sample(audio)
+        enroller.add_sample(audio)
+        with pytest.raises(PassphraseEnrollmentError, match="音素列の不整合"):
+            enroller.enroll()
+
+    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    @patch("voice_auth_engine.passphrase_auth.extract_speech")
+    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    def test_enroll_without_phoneme_threshold_returns_empty_phonemes(
+        self,
+        mock_extract_emb: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_load: MagicMock,
+        auth: PassphraseAuth,
+    ) -> None:
+        """phoneme_threshold=None の場合、空の音素列を返す。"""
+        audio = make_audio(1.0)
+        mock_load.return_value = audio
+        mock_detect.return_value = make_segments(audio)
+        mock_extract_sp.return_value = audio
+        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
+
+        enroller = auth.create_enroller()
+        enroller.add_sample(audio)
+        result = enroller.enroll()
+        assert result.phonemes == []

--- a/tests/test_passphrase_auth_integration.py
+++ b/tests/test_passphrase_auth_integration.py
@@ -35,9 +35,9 @@ class TestPassphraseAuthIntegration:
         """登録→本人認証で accepted=True。"""
         enroller = auth.create_enroller()
         enroller.add_sample(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        embedding = enroller.enroll()
+        result = enroller.enroll()
 
-        verifier = auth.create_verifier(embedding)
+        verifier = auth.create_verifier(result.embedding)
         result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
         assert result.accepted is True
         assert result.score > auth.threshold
@@ -52,9 +52,9 @@ class TestPassphraseAuthIntegration:
         """登録→他人認証で accepted=False。"""
         enroller = auth.create_enroller()
         enroller.add_sample(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        embedding = enroller.enroll()
+        result = enroller.enroll()
 
-        verifier = auth.create_verifier(embedding)
+        verifier = auth.create_verifier(result.embedding)
         result = verifier.verify(FIXTURES_DIR / other_speaker)
         assert result.accepted is False
         assert result.score < auth.threshold
@@ -69,9 +69,9 @@ class TestPassphraseAuthIntegration:
         """本人のスコアが他人のスコアより高い。"""
         enroller = auth.create_enroller()
         enroller.add_sample(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        embedding = enroller.enroll()
+        result = enroller.enroll()
 
-        verifier = auth.create_verifier(embedding)
+        verifier = auth.create_verifier(result.embedding)
         same_result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
         diff_result = verifier.verify(FIXTURES_DIR / other_speaker)
         assert same_result.score > diff_result.score
@@ -82,9 +82,9 @@ class TestPassphraseAuthIntegration:
 
         enroller = auth.create_enroller()
         enroller.add_sample(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        embedding = enroller.enroll()
+        enrollment = enroller.enroll()
 
-        restored = Embedding.from_bytes(embedding.to_bytes())
+        restored = Embedding.from_bytes(enrollment.embedding.to_bytes())
         verifier = auth.create_verifier(restored)
         result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
         assert result.accepted is True


### PR DESCRIPTION
## 概要

登録（Enrollment）パイプラインを拡張し、音素列の収集・メドイドによる基準音素列決定・サンプル間の整合性チェックを実装する。

### 変更内容

- `PassphraseExtractionResult`, `EnrollmentResult`, `PassphraseEnrollmentError` データ型を追加
- `extract_passphrase()` メソッドを新設（embedding + phonemes を返す）
- `extract_passphrase_embedding()` を後方互換ラッパーとして維持
- `PassphraseAuth` に `phoneme_threshold` パラメータを追加（デフォルト `None`）
- Enroller が embedding と phonemes の両方を蓄積し、`enroll()` が `EnrollmentResult` を返すよう変更（破壊的変更）
- ペアワイズ距離による整合性チェックとメドイド選択による基準音素列決定を実装

Closes #41