### PR TITLE
feat: add phoneme verification gate to authentication pipeline (#42)

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -32,6 +32,7 @@ from voice_auth_engine.passphrase_auth import (
     PassphraseAuthVerifier,
     PassphraseEnrollmentError,
     PassphraseExtractionResult,
+    VerificationResult,
 )
 from voice_auth_engine.passphrase_validator import (
     EmptyPassphraseError,
@@ -79,6 +80,7 @@ __all__ = [
     "PassphraseAuthVerifier",
     "PassphraseEnrollmentError",
     "PassphraseExtractionResult",
+    "VerificationResult",
     "PassphraseInfo",
     "PassphraseValidationError",
     "RecognitionError",


### PR DESCRIPTION
## 概要

認証（Verification）パイプラインに音素照合を独立ゲートとして追加。

従来は話者照合（コサイン類似度）のみで認証判定していたが、音素照合（正規化編集距離）を AND 条件として加えることで、パスフレーズの内容一致も検証できるようにした。

### 変更内容

- `VerificationResult` に `phoneme_score`, `passphrase_accepted` フィールドを追加（後方互換のデフォルト値付き）
- `PassphraseAuth.create_verifier()` に `phonemes` パラメータを追加
- `PassphraseAuthVerifier.verify()` で音素照合ゲートを実装（phonemes 未指定時は従来通り話者照合のみ）
- `VerificationResult` を `__init__.py` のエクスポートに追加
- 音素照合ゲートのテスト4件を追加