### PR TITLE
ci: add model download step to run integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v6
+      - run: uv run python scripts/download_models.py
       - run: uv run python -m pytest
 
   lint:


### PR DESCRIPTION
## 概要
CI の test ジョブにモデルダウンロードステップを追加。
モデルファイルが存在しないためスキップされていた55件のテストが実行されるようになる。