### PR TITLE
refactor: extract phoneme_extractor module from passphrase_validator

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -37,10 +37,12 @@ from voice_auth_engine.passphrase_auth import (
 from voice_auth_engine.passphrase_validator import (
     EmptyPassphraseError,
     InsufficientPhonemeError,
-    PassphraseInfo,
     PassphraseValidationError,
-    analyze_passphrase,
     validate_passphrase,
+)
+from voice_auth_engine.phoneme_extractor import (
+    Phoneme,
+    extract_phonemes,
 )
 from voice_auth_engine.speech_detector import (
     SpeechDetectorError,
@@ -81,7 +83,7 @@ __all__ = [
     "PassphraseEnrollmentError",
     "PassphraseExtractionResult",
     "VerificationResult",
-    "PassphraseInfo",
+    "Phoneme",
     "PassphraseValidationError",
     "RecognitionError",
     "RecognizerModelLoadError",
@@ -93,7 +95,7 @@ __all__ = [
     "SUPPORTED_EXTENSIONS",
     "TranscriptionResult",
     "UnsupportedExtensionError",
-    "analyze_passphrase",
+    "extract_phonemes",
     "cosine_similarity",
     "normalized_edit_distance",
     "detect_speech",

--- a/src/voice_auth_engine/passphrase_validator.py
+++ b/src/voice_auth_engine/passphrase_validator.py
@@ -1,13 +1,11 @@
-"""pyopenjtalk を使用した日本語パスフレーズの音素多様性バリデーション。"""
+"""日本語パスフレーズの音素多様性バリデーション。"""
 
 from __future__ import annotations
 
-from typing import NamedTuple
+from typing import TYPE_CHECKING
 
-import pyopenjtalk
-
-# フィルタ対象の音素記号
-_FILTERED_PHONEMES: frozenset[str] = frozenset({"pau", "cl"})
+if TYPE_CHECKING:
+    from voice_auth_engine.phoneme_extractor import Phoneme
 
 
 class PassphraseValidationError(Exception):
@@ -21,72 +19,21 @@ class EmptyPassphraseError(PassphraseValidationError):
 class InsufficientPhonemeError(PassphraseValidationError):
     """ユニーク音素数が不足。"""
 
-    def __init__(self, info: PassphraseInfo, min_required: int) -> None:
-        self.info = info
+    def __init__(self, phoneme: Phoneme, min_required: int) -> None:
+        self.phoneme = phoneme
         self.min_required = min_required
-        super().__init__(f"ユニーク音素数が不足しています: {info.unique_count} < {min_required}")
+        super().__init__(f"ユニーク音素数が不足しています: {phoneme.unique_count} < {min_required}")
 
 
-class PassphraseInfo(NamedTuple):
-    """パスフレーズの音素解析結果。"""
-
-    text: str
-    phonemes: list[str]
-    unique_phonemes: set[str]
-    unique_count: int
-
-
-def analyze_passphrase(text: str) -> PassphraseInfo:
-    """パスフレーズの音素を解析する（バリデーションなし）。
+def validate_passphrase(phoneme: Phoneme, *, min_unique_phonemes: int) -> None:
+    """音素解析結果のユニーク音素数を検証する。
 
     Args:
-        text: パスフレーズのテキスト。
-
-    Returns:
-        PassphraseInfo: 音素解析結果。
-
-    Raises:
-        EmptyPassphraseError: テキストが空または空白のみの場合。
-    """
-    if not text.strip():
-        raise EmptyPassphraseError("パスフレーズが空です")
-
-    raw_phonemes: list[str] = pyopenjtalk.g2p(text, join=False)
-    phonemes = [p for p in raw_phonemes if p not in _FILTERED_PHONEMES]
-    unique_phonemes = set(phonemes)
-
-    return PassphraseInfo(
-        text=text,
-        phonemes=phonemes,
-        unique_phonemes=unique_phonemes,
-        unique_count=len(unique_phonemes),
-    )
-
-
-def validate_passphrase(
-    text: str,
-    *,
-    min_unique_phonemes: int = 5,
-) -> PassphraseInfo:
-    """パスフレーズの音素多様性を検証する。
-
-    analyze_passphrase で解析した後、ユニーク音素数が
-    min_unique_phonemes 以上であることを確認する。
-
-    Args:
-        text: パスフレーズのテキスト。
+        phoneme: 検証対象の音素解析結果。
         min_unique_phonemes: 必要な最小ユニーク音素数。
 
-    Returns:
-        PassphraseInfo: バリデーション通過時の音素解析結果。
-
     Raises:
-        EmptyPassphraseError: テキストが空または空白のみの場合。
         InsufficientPhonemeError: ユニーク音素数が不足の場合。
     """
-    info = analyze_passphrase(text)
-
-    if info.unique_count < min_unique_phonemes:
-        raise InsufficientPhonemeError(info, min_unique_phonemes)
-
-    return info
+    if phoneme.unique_count < min_unique_phonemes:
+        raise InsufficientPhonemeError(phoneme, min_unique_phonemes)

--- a/src/voice_auth_engine/phoneme_extractor.py
+++ b/src/voice_auth_engine/phoneme_extractor.py
@@ -1,0 +1,48 @@
+"""pyopenjtalk を使用した日本語パスフレーズの音素抽出。"""
+
+from __future__ import annotations
+
+import pyopenjtalk
+
+from voice_auth_engine.passphrase_validator import EmptyPassphraseError
+
+# フィルタ対象の音素記号
+_FILTERED_PHONEMES: frozenset[str] = frozenset({"pau", "cl"})
+
+
+class Phoneme:
+    """音素解析結果。"""
+
+    def __init__(self, values: list[str]) -> None:
+        self.values = values
+
+    @property
+    def unique(self) -> set[str]:
+        """ユニーク音素の集合。"""
+        return set(self.values)
+
+    @property
+    def unique_count(self) -> int:
+        """ユニーク音素数。"""
+        return len(self.unique)
+
+
+def extract_phonemes(text: str) -> Phoneme:
+    """パスフレーズから音素を抽出する。
+
+    Args:
+        text: パスフレーズのテキスト。
+
+    Returns:
+        Phoneme: 音素解析結果。
+
+    Raises:
+        EmptyPassphraseError: テキストが空または空白のみの場合。
+    """
+    if not text.strip():
+        raise EmptyPassphraseError("パスフレーズが空です")
+
+    raw_phonemes: list[str] = pyopenjtalk.g2p(text, join=False)
+    phonemes = [p for p in raw_phonemes if p not in _FILTERED_PHONEMES]
+
+    return Phoneme(values=phonemes)

--- a/tests/test_passphrase_validator.py
+++ b/tests/test_passphrase_validator.py
@@ -3,85 +3,42 @@
 import pytest
 
 from voice_auth_engine.passphrase_validator import (
-    EmptyPassphraseError,
     InsufficientPhonemeError,
-    PassphraseInfo,
-    analyze_passphrase,
     validate_passphrase,
 )
-
-
-class TestAnalyzePassphrase:
-    """analyze_passphrase のテスト。"""
-
-    def test_extracts_phonemes(self) -> None:
-        """日本語テキストから音素リストを取得できる。"""
-        info = analyze_passphrase("こんにちは")
-        assert len(info.phonemes) > 0
-        assert all(isinstance(p, str) for p in info.phonemes)
-
-    def test_filters_pau(self) -> None:
-        """'pau' が結果に含まれない。"""
-        info = analyze_passphrase("今日はいい天気ですね")
-        assert "pau" not in info.phonemes
-
-    def test_filters_cl(self) -> None:
-        """'cl' が結果に含まれない。"""
-        info = analyze_passphrase("きっと大丈夫")
-        assert "cl" not in info.phonemes
-
-    def test_unique_count_matches_set(self) -> None:
-        """unique_count が unique_phonemes の要素数と一致する。"""
-        info = analyze_passphrase("こんにちは世界")
-        assert info.unique_count == len(info.unique_phonemes)
-
-    def test_preserves_original_text(self) -> None:
-        """info.text が入力テキストと一致する。"""
-        text = "おはようございます"
-        info = analyze_passphrase(text)
-        assert info.text == text
-
-    def test_empty_string_raises_error(self) -> None:
-        """空文字で EmptyPassphraseError が発生する。"""
-        with pytest.raises(EmptyPassphraseError):
-            analyze_passphrase("")
-
-    def test_whitespace_only_raises_error(self) -> None:
-        """空白のみで EmptyPassphraseError が発生する。"""
-        with pytest.raises(EmptyPassphraseError):
-            analyze_passphrase("   ")
+from voice_auth_engine.phoneme_extractor import Phoneme
 
 
 class TestValidatePassphrase:
     """validate_passphrase のテスト。"""
 
     def test_passes_with_sufficient_phonemes(self) -> None:
-        """十分な音素数で正常に返却される。"""
-        info = validate_passphrase("今日はいい天気ですね")
-        assert isinstance(info, PassphraseInfo)
-        assert info.unique_count >= 5
+        """十分なユニーク音素数で例外が発生しない。"""
+        phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
+        validate_passphrase(phoneme, min_unique_phonemes=5)
 
     def test_raises_with_insufficient_phonemes(self) -> None:
-        """音素不足で InsufficientPhonemeError が発生する。"""
+        """ユニーク音素数不足で InsufficientPhonemeError が発生する。"""
+        phoneme = Phoneme(values=["a", "i"])
         with pytest.raises(InsufficientPhonemeError):
-            validate_passphrase("あ", min_unique_phonemes=10)
+            validate_passphrase(phoneme, min_unique_phonemes=5)
 
-    def test_custom_min_unique_phonemes(self) -> None:
-        """カスタム閾値での動作を確認する。"""
-        info = validate_passphrase("こんにちは", min_unique_phonemes=1)
-        assert info.unique_count >= 1
-
-    def test_error_contains_info(self) -> None:
-        """例外に info と min_required が含まれる。"""
+    def test_error_contains_phoneme(self) -> None:
+        """例外に phoneme と min_required が含まれる。"""
+        phoneme = Phoneme(values=["a"])
         with pytest.raises(InsufficientPhonemeError) as exc_info:
-            validate_passphrase("あ", min_unique_phonemes=100)
+            validate_passphrase(phoneme, min_unique_phonemes=100)
         err = exc_info.value
-        assert isinstance(err.info, PassphraseInfo)
+        assert err.phoneme is phoneme
         assert err.min_required == 100
 
     def test_boundary_exact_minimum(self) -> None:
         """境界値（ちょうど閾値）で通過する。"""
-        info = analyze_passphrase("こんにちは")
-        exact = info.unique_count
-        result = validate_passphrase("こんにちは", min_unique_phonemes=exact)
-        assert result.unique_count == exact
+        phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
+        validate_passphrase(phoneme, min_unique_phonemes=5)
+
+    def test_boundary_one_below_minimum(self) -> None:
+        """境界値（閾値-1）で例外が発生する。"""
+        phoneme = Phoneme(values=["a", "i", "u", "e"])
+        with pytest.raises(InsufficientPhonemeError):
+            validate_passphrase(phoneme, min_unique_phonemes=5)

--- a/tests/test_phoneme_extractor.py
+++ b/tests/test_phoneme_extractor.py
@@ -1,0 +1,45 @@
+"""phoneme_extractor モジュールのテスト。"""
+
+import pytest
+
+from voice_auth_engine.passphrase_validator import EmptyPassphraseError
+from voice_auth_engine.phoneme_extractor import (
+    Phoneme,
+    extract_phonemes,
+)
+
+
+class TestExtractPhonemes:
+    """extract_phonemes のテスト。"""
+
+    def test_returns_phoneme(self) -> None:
+        """Phoneme を返す。"""
+        phoneme = extract_phonemes("こんにちは")
+        assert isinstance(phoneme, Phoneme)
+        assert len(phoneme.values) > 0
+        assert all(isinstance(p, str) for p in phoneme.values)
+
+    def test_unique_count_matches_set(self) -> None:
+        """unique_count が unique の要素数と一致する。"""
+        phoneme = extract_phonemes("こんにちは世界")
+        assert phoneme.unique_count == len(phoneme.unique)
+
+    def test_filters_pau(self) -> None:
+        """'pau' が結果に含まれない。"""
+        phoneme = extract_phonemes("今日はいい天気ですね")
+        assert "pau" not in phoneme.values
+
+    def test_filters_cl(self) -> None:
+        """'cl' が結果に含まれない。"""
+        phoneme = extract_phonemes("きっと大丈夫")
+        assert "cl" not in phoneme.values
+
+    def test_empty_string_raises_error(self) -> None:
+        """空文字で EmptyPassphraseError が発生する。"""
+        with pytest.raises(EmptyPassphraseError):
+            extract_phonemes("")
+
+    def test_whitespace_only_raises_error(self) -> None:
+        """空白のみで EmptyPassphraseError が発生する。"""
+        with pytest.raises(EmptyPassphraseError):
+            extract_phonemes("   ")


### PR DESCRIPTION
## 概要

`passphrase_validator.py` に同居していた音素抽出ロジックを専用の `phoneme_extractor` モジュールに分離し、責務を明確化する。

- `phoneme_extractor.py` を新規作成し、`Phoneme` クラスと `extract_phonemes()` 関数を配置
- `Phoneme` クラスを簡素化: 冗長なフィールド (`unique_phonemes`, `unique_count`) を削除し、`values` から算出するプロパティに変更
- `PassphraseExtractionResult.phonemes: list[str]` → `phoneme: Phoneme` に変更し型を強化
- `passphrase_validator.py` はバリデーション責務のみに集中