### PR TITLE
feat: add lazy model download and dynamic model directory resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,11 +7,15 @@ requires-python = ">=3.13"
 dependencies = [
     "av",
     "numpy",
+    "platformdirs",
     "pyopenjtalk",
     "sherpa-onnx",
     "sherpa-onnx-core",
     "tqdm>=4.67.3",
 ]
+
+[project.scripts]
+voice-auth-engine = "voice_auth_engine.cli:main"
 
 [build-system]
 requires = ["hatchling"]

--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -1,12 +1,10 @@
 """Download model files for sherpa-onnx."""
 
-from voice_auth_engine.model_config import MODELS_DIR
 from voice_auth_engine.model_downloader import ModelDownloader
 
 
 def main() -> None:
-    downloader = ModelDownloader(models_dir=MODELS_DIR)
-    downloader.download_all()
+    ModelDownloader().download_all()
 
 
 if __name__ == "__main__":

--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -24,6 +24,8 @@ from voice_auth_engine.embedding_extractor import (
     extract_embedding,
 )
 from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
+from voice_auth_engine.model_config import ModelConfig
+from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
 from voice_auth_engine.passphrase_auth import (
     EnrollmentResult,
     PassphraseAuth,
@@ -75,6 +77,8 @@ __all__ = [
     "EmptyAudioError",
     "EmptyPassphraseError",
     "EnrollmentResult",
+    "ModelDownloadError",
+    "ModelDownloader",
     "InsufficientDurationError",
     "InsufficientPhonemeError",
     "PassphraseAuth",
@@ -96,6 +100,7 @@ __all__ = [
     "SUPPORTED_EXTENSIONS",
     "TranscriptionResult",
     "UnsupportedExtensionError",
+    "ModelConfig",
     "extract_phonemes",
     "cosine_similarity",
     "normalized_edit_distance",

--- a/src/voice_auth_engine/cli.py
+++ b/src/voice_auth_engine/cli.py
@@ -1,0 +1,23 @@
+"""voice-auth-engine CLI エントリポイント。"""
+
+import argparse
+
+from voice_auth_engine.model_downloader import ModelDownloader
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(prog="voice-auth-engine")
+    subparsers = parser.add_subparsers(dest="command")
+
+    subparsers.add_parser("download-models", help="全モデルをダウンロードする")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "download-models":
+        ModelDownloader().download_all()
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/voice_auth_engine/embedding_extractor.py
+++ b/src/voice_auth_engine/embedding_extractor.py
@@ -11,6 +11,7 @@ import sherpa_onnx
 
 from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.model_config import campplus_config
+from voice_auth_engine.model_downloader import ModelDownloader
 
 
 class EmbeddingExtractorError(Exception):
@@ -59,7 +60,7 @@ def extract_embedding(
         EmbeddingExtractionError: 埋め込み抽出処理に失敗した場合。
     """
     if model_path is None:
-        model_path = campplus_config.path
+        model_path = ModelDownloader().ensure_download(campplus_config)
     model_path = Path(model_path)
 
     if not model_path.exists():

--- a/src/voice_auth_engine/speech_detector.py
+++ b/src/voice_auth_engine/speech_detector.py
@@ -10,6 +10,7 @@ import sherpa_onnx
 
 from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.model_config import silero_vad_config
+from voice_auth_engine.model_downloader import ModelDownloader
 
 
 class SpeechDetectorError(Exception):
@@ -60,7 +61,7 @@ def detect_speech(
         SpeechDetectorModelLoadError: モデルの読み込みに失敗した場合。
     """
     if model_path is None:
-        model_path = silero_vad_config.path
+        model_path = ModelDownloader().ensure_download(silero_vad_config)
     model_path = Path(model_path)
 
     if not model_path.exists():

--- a/src/voice_auth_engine/speech_recognizer.py
+++ b/src/voice_auth_engine/speech_recognizer.py
@@ -9,6 +9,7 @@ import sherpa_onnx
 
 from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.model_config import sense_voice_config
+from voice_auth_engine.model_downloader import ModelDownloader
 
 
 class SpeechRecognizerError(Exception):
@@ -52,7 +53,7 @@ def transcribe(
         RecognitionError: 音声認識処理に失敗した場合。
     """
     if model_dir is None:
-        model_dir = sense_voice_config.path
+        model_dir = ModelDownloader().ensure_download(sense_voice_config)
     model_dir = Path(model_dir)
 
     if not model_dir.exists():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+"""Tests for CLI entry point."""
+
+from unittest.mock import patch
+
+from voice_auth_engine.cli import main
+
+
+class TestCli:
+    def test_download_models_calls_downloader(self):
+        with patch("voice_auth_engine.cli.ModelDownloader") as mock_cls:
+            main(["download-models"])
+            mock_cls.return_value.download_all.assert_called_once()
+
+    def test_no_command_prints_help(self, capsys):
+        main([])
+        captured = capsys.readouterr()
+        assert "download-models" in captured.out

--- a/tests/test_model_config.py
+++ b/tests/test_model_config.py
@@ -1,6 +1,8 @@
-"""Tests for ModelConfig and DEFAULT_MODELS."""
+"""Tests for ModelConfig."""
 
 from pathlib import Path
+
+import pytest
 
 from voice_auth_engine.model_config import ModelConfig
 
@@ -28,3 +30,40 @@ class TestModelConfig:
         )
         assert config.archive is True
         assert config.inner_dir == "inner"
+
+
+class TestGetModelsDir:
+    def test_env_var_takes_priority(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        env_dir = tmp_path / "env-models"
+        monkeypatch.setenv("VOICE_AUTH_ENGINE_MODELS_DIR", str(env_dir))
+        assert ModelConfig.get_models_dir() == env_dir
+
+    def test_legacy_dir_when_exists_and_non_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.delenv("VOICE_AUTH_ENGINE_MODELS_DIR", raising=False)
+        legacy = tmp_path / "models"
+        legacy.mkdir()
+        (legacy / "dummy.onnx").write_text("dummy")
+        monkeypatch.setattr("voice_auth_engine.model_config.PROJECT_ROOT", tmp_path)
+        assert ModelConfig.get_models_dir() == legacy
+
+    def test_legacy_dir_skipped_when_empty(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        monkeypatch.delenv("VOICE_AUTH_ENGINE_MODELS_DIR", raising=False)
+        legacy = tmp_path / "models"
+        legacy.mkdir()
+        monkeypatch.setattr("voice_auth_engine.model_config.PROJECT_ROOT", tmp_path)
+        result = ModelConfig.get_models_dir()
+        assert result != legacy
+        assert result.name == "models"
+
+    def test_falls_back_to_cache_dir(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+        monkeypatch.delenv("VOICE_AUTH_ENGINE_MODELS_DIR", raising=False)
+        # PROJECT_ROOT/models does not exist
+        monkeypatch.setattr("voice_auth_engine.model_config.PROJECT_ROOT", tmp_path)
+        monkeypatch.setattr(
+            "voice_auth_engine.model_config.platformdirs.user_cache_dir",
+            lambda app: str(tmp_path / "cache" / app),
+        )
+        result = ModelConfig.get_models_dir()
+        assert result == tmp_path / "cache" / "voice-auth-engine" / "models"

--- a/tests/test_model_downloader.py
+++ b/tests/test_model_downloader.py
@@ -1,9 +1,12 @@
 """Tests for ModelDownloader."""
 
 from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from voice_auth_engine.model_config import DEFAULT_MODELS, ModelConfig
-from voice_auth_engine.model_downloader import ModelDownloader
+from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
 
 
 class TestModelDownloader:
@@ -72,3 +75,58 @@ class TestModelDownloader:
 
         downloader = ModelDownloader(models_dir=tmp_path)
         assert downloader.is_downloaded(model) is False
+
+
+class TestEnsureDownload:
+    def test_returns_path_when_already_downloaded(self, tmp_path: Path):
+        model = ModelConfig(
+            name="test",
+            url="https://example.com/model.onnx",
+            dest=Path("sub") / "model.onnx",
+        )
+        dest = tmp_path / model.dest
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_text("dummy")
+
+        downloader = ModelDownloader(models_dir=tmp_path)
+        result = downloader.ensure_download(model)
+        assert result == dest
+
+    def test_downloads_when_not_present(self, tmp_path: Path):
+        model = ModelConfig(
+            name="test",
+            url="https://example.com/model.onnx",
+            dest=Path("sub") / "model.onnx",
+        )
+
+        def fake_download(self, m):
+            dest = self.models_dir / m.dest
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text("downloaded")
+
+        with patch.object(ModelDownloader, "download", fake_download):
+            downloader = ModelDownloader(models_dir=tmp_path)
+            result = downloader.ensure_download(model)
+
+        assert result == tmp_path / model.dest
+
+    def test_raises_model_download_error_on_failure(self, tmp_path: Path):
+        model = ModelConfig(
+            name="test",
+            url="https://example.com/model.onnx",
+            dest=Path("sub") / "model.onnx",
+        )
+
+        with (
+            patch.object(ModelDownloader, "download", side_effect=RuntimeError("network error")),
+            pytest.raises(ModelDownloadError, match="network error"),
+        ):
+            downloader = ModelDownloader(models_dir=tmp_path)
+            downloader.ensure_download(model)
+
+
+class TestModelsDir:
+    def test_defaults_to_get_models_dir(self, tmp_path: Path):
+        with patch.object(ModelConfig, "get_models_dir", return_value=tmp_path):
+            downloader = ModelDownloader()
+        assert downloader.models_dir == tmp_path

--- a/uv.lock
+++ b/uv.lock
@@ -469,6 +469,7 @@ source = { editable = "." }
 dependencies = [
     { name = "av" },
     { name = "numpy" },
+    { name = "platformdirs" },
     { name = "pyopenjtalk" },
     { name = "sherpa-onnx" },
     { name = "sherpa-onnx-core" },
@@ -488,6 +489,7 @@ dev = [
 requires-dist = [
     { name = "av" },
     { name = "numpy" },
+    { name = "platformdirs" },
     { name = "pyopenjtalk" },
     { name = "sherpa-onnx" },
     { name = "sherpa-onnx-core" },


### PR DESCRIPTION
## 概要

モデルディレクトリの解決を動的化し、初回利用時の自動ダウンロードを実装。

ライブラリとして `pip install` した場合、従来の `PROJECT_ROOT/models` が site-packages を指すため動作しなかった。Hugging Face 方式に倣い、以下のハイブリッド方式を導入:

- **動的モデルディレクトリ解決** (`ModelConfig.get_models_dir()`): 環境変数 → レガシーディレクトリ → OS標準キャッシュ（platformdirs）の3段階で解決
- **遅延ダウンロード** (`ModelDownloader.ensure_download()`): モデル未取得時に自動ダウンロード
- **CLI エントリポイント** (`voice-auth-engine download-models`): 事前ダウンロード用コマンド