### PR TITLE
fix: bump version to 0.3.0 to fix release CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voice-auth-engine"
-version = "0.2.0"
+version = "0.3.0"
 description = "Voice authentication engine"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -464,7 +464,7 @@ wheels = [
 
 [[package]]
 name = "voice-auth-engine"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## 概要

タグ v0.3.0 と pyproject.toml のバージョン（0.2.0）が不一致していたため、リリースCIが失敗していた。
pyproject.toml および uv.lock のバージョンを 0.3.0 に更新することで修正。