### PR TITLE
fix: remove deprecated macOS x86_64 build target

### DIFF
--- a/.github/workflows/build-pyopenjtalk.yml
+++ b/.github/workflows/build-pyopenjtalk.yml
@@ -19,8 +19,6 @@ jobs:
           #   arch: aarch64
           - os: macos-latest
             arch: arm64
-          - os: macos-13
-            arch: x86_64
     runs-on: ${{ matrix.os }}
     steps:
       - name: Download pyopenjtalk source


### PR DESCRIPTION
## 概要

GitHub が macos-13 ランナーを廃止したため、pyopenjtalk wheel ビルドの macos-13 (x86_64) ジョブが毎回キャンセルされ、upload-wheels がスキップされていた。

不要な macOS x86_64 ビルドターゲットをマトリクスから削除。