### PR TITLE
ci: auto-release on version bump and make pyopenjtalk build manual

### DIFF
--- a/.github/workflows/build-pyopenjtalk.yml
+++ b/.github/workflows/build-pyopenjtalk.yml
@@ -1,8 +1,7 @@
 name: Build pyopenjtalk wheels
 
 on:
-  push:
-    tags: ["v*"]
+  workflow_dispatch:
 
 env:
   PYOPENJTALK_VERSION: "0.4.1"
@@ -48,7 +47,6 @@ jobs:
           path: wheelhouse/*.whl
 
   upload-wheels:
-    if: startsWith(github.ref, 'refs/tags/')
     needs: [build-wheels]
     runs-on: ubuntu-latest
     permissions:
@@ -60,8 +58,17 @@ jobs:
           pattern: wheel-*
           merge-multiple: true
 
-      - name: Upload to GitHub Release
+      - name: Get latest release tag
+        id: latest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          tag=$(gh release view --json tagName -q .tagName)
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to latest GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.latest.outputs.tag }}
           files: wheels/*.whl
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,14 +2,38 @@ name: Release
 
 on:
   push:
-    tags: ["v*"]
+    branches: [main]
+    paths: [pyproject.toml]
 
 jobs:
+  check-version:
+    runs-on: ubuntu-latest
+    outputs:
+      changed: ${{ steps.version.outputs.changed }}
+      version: ${{ steps.version.outputs.current }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Check version change
+        id: version
+        run: |
+          current=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          previous=$(git show HEAD~1:pyproject.toml | python3 -c "import tomllib,sys; print(tomllib.load(sys.stdin.buffer)['project']['version'])")
+          echo "current=$current" >> "$GITHUB_OUTPUT"
+          echo "previous=$previous" >> "$GITHUB_OUTPUT"
+          if [ "$current" != "$previous" ]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
   ci:
+    needs: [check-version]
+    if: needs.check-version.outputs.changed == 'true'
     uses: ./.github/workflows/ci.yml
 
   release:
-    needs: [ci]
+    needs: [check-version, ci]
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -20,17 +44,15 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Verify tag matches package version
+      - name: Create tag
         run: |
-          tag="${GITHUB_REF_NAME#v}"
-          version=$(uv run python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          if [ "$tag" != "$version" ]; then
-            echo "::error::Tag v$tag does not match pyproject.toml version $version"
-            exit 1
-          fi
+          tag="v${{ needs.check-version.outputs.version }}"
+          git tag "$tag"
+          git push origin "$tag"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: v${{ needs.check-version.outputs.version }}
           generate_release_notes: true
           files: dist/*


### PR DESCRIPTION
## 概要
- `release.yml`: タグトリガーから `main` push 時の `pyproject.toml` バージョン変更検知に変更。バージョンが上がると自動でタグ作成・リリースを実行
- `build-pyopenjtalk.yml`: タグトリガーから `workflow_dispatch`（手動実行）に変更。ビルドした wheel は最新リリースにアップロード