### PR TITLE
chore: remove redundant CI runs on main branch merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,11 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
-  workflow_call:
 
 jobs:
   test:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,13 +27,9 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-  ci:
+  release:
     needs: [check-version]
     if: needs.check-version.outputs.changed == 'true'
-    uses: ./.github/workflows/ci.yml
-
-  release:
-    needs: [check-version, ci]
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 概要
mainブランチへのマージ時に不要なCI実行が走る問題を修正。

- `ci.yml`: `push`トリガーと`workflow_call`トリガーを削除し、PRのみで実行されるように変更
- `release.yml`: `ci`ジョブを削除し、`release`ジョブに直接バージョン変更チェックの`if`条件を追加