### PR TITLE
chore: remove pyopenjtalk custom wheel sources and bump version to 0.5.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voice-auth-engine"
-version = "0.5.1"
+version = "0.5.2"
 description = "Voice authentication engine"
 readme = "README.md"
 requires-python = ">=3.13"
@@ -35,12 +35,6 @@ testpaths = ["tests"]
 addopts = "--cov=voice_auth_engine --cov-report=term-missing"
 filterwarnings = [
     "ignore:Python 3.14 will.*filter extracted tar archives:DeprecationWarning",
-]
-
-[tool.uv.sources]
-pyopenjtalk = [
-    { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", marker = "sys_platform == 'darwin' and platform_machine == 'arm64'" },
-    { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -281,100 +281,11 @@ wheels = [
 name = "pyopenjtalk"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')",
-]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "tqdm", marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
+    { name = "numpy" },
+    { name = "tqdm" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/74/ccd31c696f047ba381f9b11a504bf1199756c3f30f3de64e3eeb83e10b4a/pyopenjtalk-0.4.1.tar.gz", hash = "sha256:d5ada46f7fc2b52c1c79c273eb9668ff6ad7ab276a8db9d8be119ef93440f0dc", size = 1397999, upload-time = "2025-04-08T06:27:46.528Z" }
-
-[[package]]
-name = "pyopenjtalk"
-version = "0.4.1"
-source = { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-macosx_11_0_arm64.whl" }
-resolution-markers = [
-    "platform_machine == 'arm64' and sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "numpy", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "tqdm", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-]
-wheels = [
-    { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d35e34e0346916b69ce6b73b3caad73fdaa22dc453bba50a9b4434f904bfdae0" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=19.19b0,<=20.8" },
-    { name = "click", marker = "extra == 'dev'", specifier = "<8.1.0" },
-    { name = "cython", marker = "extra == 'dev'", specifier = ">=0.29.16" },
-    { name = "flake8", marker = "extra == 'dev'", specifier = ">=3.7,<4" },
-    { name = "flake8-bugbear", marker = "extra == 'dev'" },
-    { name = "importlib-metadata", marker = "extra == 'dev'", specifier = "<5.0" },
-    { name = "importlib-resources", marker = "python_full_version < '3.9'" },
-    { name = "ipython", marker = "extra == 'docs'" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=4.3,<5.2.0" },
-    { name = "jinja2", marker = "extra == 'docs'", specifier = ">=3.0.1" },
-    { name = "jupyter", marker = "extra == 'docs'" },
-    { name = "marine", marker = "extra == 'marine'", specifier = ">=0.0.5" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "<=0.910" },
-    { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.8.6" },
-    { name = "numpy", specifier = ">=1.20.0" },
-    { name = "pandoc", marker = "extra == 'docs'" },
-    { name = "pysen", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "scipy", marker = "extra == 'test'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
-    { name = "tqdm" },
-    { name = "types-decorator", marker = "extra == 'dev'" },
-    { name = "types-setuptools", marker = "extra == 'dev'" },
-]
-provides-extras = ["docs", "dev", "test", "marine"]
-
-[[package]]
-name = "pyopenjtalk"
-version = "0.4.1"
-source = { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" }
-resolution-markers = [
-    "platform_machine == 'x86_64' and sys_platform == 'linux'",
-]
-dependencies = [
-    { name = "numpy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "tqdm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-]
-wheels = [
-    { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cd7ecb4911c936320150c7ddd2ea4b8fc2872f3af5709a8a527d4a685f8373e6" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "black", marker = "extra == 'dev'", specifier = ">=19.19b0,<=20.8" },
-    { name = "click", marker = "extra == 'dev'", specifier = "<8.1.0" },
-    { name = "cython", marker = "extra == 'dev'", specifier = ">=0.29.16" },
-    { name = "flake8", marker = "extra == 'dev'", specifier = ">=3.7,<4" },
-    { name = "flake8-bugbear", marker = "extra == 'dev'" },
-    { name = "importlib-metadata", marker = "extra == 'dev'", specifier = "<5.0" },
-    { name = "importlib-resources", marker = "python_full_version < '3.9'" },
-    { name = "ipython", marker = "extra == 'docs'" },
-    { name = "isort", marker = "extra == 'dev'", specifier = ">=4.3,<5.2.0" },
-    { name = "jinja2", marker = "extra == 'docs'", specifier = ">=3.0.1" },
-    { name = "jupyter", marker = "extra == 'docs'" },
-    { name = "marine", marker = "extra == 'marine'", specifier = ">=0.0.5" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = "<=0.910" },
-    { name = "nbsphinx", marker = "extra == 'docs'", specifier = ">=0.8.6" },
-    { name = "numpy", specifier = ">=1.20.0" },
-    { name = "pandoc", marker = "extra == 'docs'" },
-    { name = "pysen", marker = "extra == 'dev'" },
-    { name = "pytest", marker = "extra == 'test'" },
-    { name = "scipy", marker = "extra == 'test'" },
-    { name = "sphinx-rtd-theme", marker = "extra == 'docs'" },
-    { name = "tqdm" },
-    { name = "types-decorator", marker = "extra == 'dev'" },
-    { name = "types-setuptools", marker = "extra == 'dev'" },
-]
-provides-extras = ["docs", "dev", "test", "marine"]
 
 [[package]]
 name = "pytest"
@@ -558,15 +469,13 @@ wheels = [
 
 [[package]]
 name = "voice-auth-engine"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "av" },
     { name = "numpy" },
     { name = "platformdirs" },
-    { name = "pyopenjtalk", version = "0.4.1", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "pyopenjtalk", version = "0.4.1", source = { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-macosx_11_0_arm64.whl" }, marker = "platform_machine == 'arm64' and sys_platform == 'darwin'" },
-    { name = "pyopenjtalk", version = "0.4.1", source = { url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyopenjtalk" },
     { name = "sherpa-onnx" },
     { name = "sherpa-onnx-core" },
     { name = "tqdm" },
@@ -586,9 +495,7 @@ requires-dist = [
     { name = "av" },
     { name = "numpy" },
     { name = "platformdirs" },
-    { name = "pyopenjtalk", marker = "(platform_machine != 'arm64' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform == 'linux') or (sys_platform != 'darwin' and sys_platform != 'linux')" },
-    { name = "pyopenjtalk", marker = "platform_machine == 'arm64' and sys_platform == 'darwin'", url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-macosx_11_0_arm64.whl" },
-    { name = "pyopenjtalk", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", url = "https://github.com/muzin00/voice-auth-engine/releases/download/v0.5.0/pyopenjtalk-0.4.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl" },
+    { name = "pyopenjtalk" },
     { name = "sherpa-onnx" },
     { name = "sherpa-onnx-core" },
     { name = "tqdm", specifier = ">=4.67.3" },


### PR DESCRIPTION
## 概要
- pyopenjtalkのインストール元をカスタムビルドwheel（GitHub Releases）からPyPIに変更
- バージョンを0.5.1から0.5.2に更新