### PR TITLE
feat(extract): add transcription and speech_duration to PassphraseExtractionResult

### DIFF
--- a/src/voice_auth_engine/audio_preprocessor.py
+++ b/src/voice_auth_engine/audio_preprocessor.py
@@ -30,6 +30,11 @@ class AudioData(NamedTuple):
     sample_rate: int  # 常に 16000
 
     @property
+    def duration(self) -> float:
+        """音声の長さ（秒）。"""
+        return len(self.samples) / self.sample_rate
+
+    @property
     def samples_f32(self) -> npt.NDArray[np.float32]:
         """int16 サンプルを [-1.0, 1.0] の float32 に正規化して返す。"""
         return self.samples.astype(np.float32) / 32768.0

--- a/src/voice_auth_engine/audio_validator.py
+++ b/src/voice_auth_engine/audio_validator.py
@@ -58,7 +58,7 @@ def validate_audio(
     if len(audio.samples) == 0:
         raise EmptyAudioError("音声サンプルが空です")
 
-    duration_seconds = len(audio.samples) / audio.sample_rate
+    duration_seconds = audio.duration
 
     if duration_seconds < min_seconds:
         raise InsufficientDurationError(duration_seconds, min_seconds)

--- a/src/voice_auth_engine/passphrase_auth.py
+++ b/src/voice_auth_engine/passphrase_auth.py
@@ -28,6 +28,8 @@ class PassphraseExtractionResult(NamedTuple):
 
     embedding: Embedding
     phoneme: Phoneme
+    transcription: str  # 音声認識による書き起こしテキスト
+    speech_duration: float  # VAD後の発話区間の長さ（秒）
 
 
 class EnrollmentResult(NamedTuple):
@@ -137,13 +139,20 @@ class PassphraseAuth:
         validate_audio(speech, min_seconds=self._min_speech_seconds)
         if self._min_unique_phonemes is not None or self._phoneme_threshold is not None:
             result = transcribe(speech)
+            transcription = result.text
             phoneme = extract_phonemes(result.text)
             if self._min_unique_phonemes is not None:
                 validate_passphrase(phoneme, min_unique_phonemes=self._min_unique_phonemes)
         else:
+            transcription = ""
             phoneme = Phoneme(values=[])
         embedding = extract_embedding(speech)
-        return PassphraseExtractionResult(embedding=embedding, phoneme=phoneme)
+        return PassphraseExtractionResult(
+            embedding=embedding,
+            phoneme=phoneme,
+            transcription=transcription,
+            speech_duration=speech.duration,
+        )
 
     def extract_passphrase_embedding(self, audio: AudioInput) -> Embedding:
         """音声入力から検証済み埋め込みベクトルを抽出する（後方互換）。

--- a/tests/test_passphrase_auth.py
+++ b/tests/test_passphrase_auth.py
@@ -15,6 +15,7 @@ from voice_auth_engine.passphrase_auth import (
     PassphraseAuth,
     PassphraseAuthEnroller,
     PassphraseAuthVerifier,
+    PassphraseExtractionResult,
 )
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 from voice_auth_engine.phoneme_extractor import Phoneme
@@ -578,3 +579,46 @@ class TestPassphraseAuthVerifierPhonemes:
         assert result.voiceprint_accepted is True
         assert result.passphrase_score is None
         assert result.passphrase_accepted is None
+
+
+class TestExtractPassphrase:
+    """extract_passphrase の戻り値テスト。"""
+
+    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
+    @patch("voice_auth_engine.passphrase_auth.transcribe")
+    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.passphrase_auth.extract_speech")
+    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    def test_result_contains_all_fields(
+        self,
+        mock_load: MagicMock,
+        mock_detect: MagicMock,
+        mock_extract_sp: MagicMock,
+        mock_extract_emb: MagicMock,
+        mock_transcribe: MagicMock,
+        mock_extract_phonemes: MagicMock,
+    ) -> None:
+        """全フィールド（embedding, phoneme, transcription, speech_duration）が返る。"""
+        auth = PassphraseAuth(
+            threshold=0.5,
+            min_speech_seconds=0.1,
+            min_unique_phonemes=5,
+        )
+        original_audio = make_audio(5.0)
+        speech_audio = make_audio(1.5)
+        mock_load.return_value = original_audio
+        mock_detect.return_value = make_segments(original_audio)
+        mock_extract_sp.return_value = speech_audio
+        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
+        mock_transcribe.return_value = MagicMock(text="こんにちは世界")
+        phonemes = ["k", "o", "N", "n", "i", "ch", "w", "a", "s", "e", "k", "a", "i"]
+        mock_extract_phonemes.return_value = Phoneme(values=phonemes)
+
+        result = auth.extract_passphrase(original_audio)
+
+        assert isinstance(result, PassphraseExtractionResult)
+        assert isinstance(result.embedding, Embedding)
+        assert result.phoneme.values == phonemes
+        assert result.transcription == "こんにちは世界"
+        assert result.speech_duration == pytest.approx(1.5)


### PR DESCRIPTION
## 概要

`PassphraseExtractionResult` に `transcription`（書き起こしテキスト）と `speech_duration`（VAD後の発話時間）を追加する。

voice-auth-app 側で Voice モデルに保存する必要がある値だが、`extract_passphrase()` 内部で算出済みにもかかわらず戻り値に含まれていなかった。

### 変更内容

- `AudioData` に `duration` プロパティを追加し、時間算出ロジックを一元化
- `PassphraseExtractionResult` に `transcription: str` と `speech_duration: float` を追加
- `extract_passphrase()` で両フィールドを返すように変更（音素チェック無効時の `transcription` は空文字列）
- `audio_validator.py` の重複した時間算出を `AudioData.duration` に置き換え
- 全フィールドを網羅するテストを追加

Closes #72