### PR TITLE
refactor(enroller): replace mean embedding with medoid selection

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -23,7 +23,7 @@ from voice_auth_engine.embedding_extractor import (
     EmbeddingModelLoadError,
     extract_embedding,
 )
-from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
+from voice_auth_engine.math import cosine_distance, cosine_similarity, normalized_edit_distance
 from voice_auth_engine.model_config import ModelConfig
 from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
 from voice_auth_engine.passphrase_auth import (
@@ -102,6 +102,7 @@ __all__ = [
     "UnsupportedExtensionError",
     "ModelConfig",
     "extract_phonemes",
+    "cosine_distance",
     "cosine_similarity",
     "normalized_edit_distance",
     "detect_speech",

--- a/src/voice_auth_engine/math.py
+++ b/src/voice_auth_engine/math.py
@@ -32,6 +32,18 @@ def cosine_similarity(
     return float(np.dot(a, b) / (norm_a * norm_b))
 
 
+def cosine_distance(
+    a: npt.NDArray[np.float32],
+    b: npt.NDArray[np.float32],
+) -> float:
+    """2つのベクトルのコサイン距離を計算する。
+
+    Returns:
+        コサイン距離 [0.0, 2.0]。0.0 = 完全一致。
+    """
+    return 1.0 - cosine_similarity(a, b)
+
+
 def normalized_edit_distance(a: Sequence[T], b: Sequence[T]) -> float:
     """2つの系列の正規化編集距離を計算する。
 
@@ -70,19 +82,19 @@ def normalized_edit_distance(a: Sequence[T], b: Sequence[T]) -> float:
 
 
 def pairwise_distances(
-    sequences: Sequence[Sequence[T]],
-    distance_fn: Callable[[Sequence[T], Sequence[T]], float] = normalized_edit_distance,
+    items: Sequence[T],
+    distance_fn: Callable[[T, T], float] = normalized_edit_distance,  # type: ignore[assignment]
 ) -> list[list[float]]:
     """全ペア間の距離行列を計算する。
 
     Returns:
-        n×n の対称行列。distances[i][j] は sequences[i] と sequences[j] の距離。
+        n×n の対称行列。distances[i][j] は items[i] と items[j] の距離。
     """
-    n = len(sequences)
+    n = len(items)
     distances = [[0.0] * n for _ in range(n)]
     for i in range(n):
         for j in range(i + 1, n):
-            d = distance_fn(sequences[i], sequences[j])
+            d = distance_fn(items[i], items[j])
             distances[i][j] = d
             distances[j][i] = d
     return distances

--- a/src/voice_auth_engine/passphrase_auth.py
+++ b/src/voice_auth_engine/passphrase_auth.py
@@ -4,12 +4,16 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-import numpy as np
-
 from voice_auth_engine.audio_preprocessor import AudioInput, load_audio
 from voice_auth_engine.audio_validator import validate_audio
 from voice_auth_engine.embedding_extractor import Embedding, extract_embedding
-from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
+from voice_auth_engine.math import (
+    cosine_distance,
+    cosine_similarity,
+    normalized_edit_distance,
+    pairwise_distances,
+    select_medoid,
+)
 from voice_auth_engine.passphrase_validator import (
     validate_passphrase,
     validate_phoneme_consistency,
@@ -37,6 +41,7 @@ class EnrollmentResult(NamedTuple):
 
     embedding: Embedding
     phoneme: Phoneme  # 基準音素（メドイドで決定）
+    selected_index: int  # 選択されたサンプルのインデックス（add_sample の順序）
 
 
 class VerificationResult(NamedTuple):
@@ -174,7 +179,7 @@ class PassphraseAuth:
 class PassphraseAuthEnroller:
     """声紋登録 (Enroller)。
 
-    音声サンプルを蓄積し、平均埋め込みベクトルと基準音素列を算出する。
+    音声サンプルを蓄積し、最適な1サンプル（メドイド）を選択する。
     ``PassphraseAuth.create_enroller()`` から生成する。
     """
 
@@ -199,7 +204,9 @@ class PassphraseAuthEnroller:
         self._phoneme_samples.append(result.phoneme)
 
     def enroll(self) -> EnrollmentResult:
-        """蓄積サンプルの平均埋め込みベクトルと基準音素列を返す。
+        """蓄積サンプルからメドイド（最適な1サンプル）を選択して返す。
+
+        embedding のコサイン距離に基づくメドイドを選択する。
 
         Raises:
             ValueError: サンプルが蓄積されていない場合。
@@ -207,8 +214,15 @@ class PassphraseAuthEnroller:
         """
         if not self._embeddings:
             raise ValueError("サンプルが蓄積されていません")
-        mean_values = np.mean([e.values for e in self._embeddings], axis=0)
-        embedding = Embedding(values=mean_values)
+        if len(self._embeddings) == 1:
+            selected_index = 0
+        else:
+            distances = pairwise_distances(
+                [e.values for e in self._embeddings],
+                distance_fn=cosine_distance,
+            )
+            selected_index = select_medoid(distances)
+        embedding = self._embeddings[selected_index]
         if self._auth._phoneme_threshold is not None:
             validate_phoneme_consistency(
                 self._phoneme_samples, threshold=self._auth._phoneme_threshold
@@ -216,7 +230,7 @@ class PassphraseAuthEnroller:
             phoneme = Phoneme.select_reference(self._phoneme_samples)
         else:
             phoneme = Phoneme(values=[])
-        return EnrollmentResult(embedding=embedding, phoneme=phoneme)
+        return EnrollmentResult(embedding=embedding, phoneme=phoneme, selected_index=selected_index)
 
     @property
     def sample_count(self) -> int:

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.math import (
+    cosine_distance,
     cosine_similarity,
     normalized_edit_distance,
     pairwise_distances,
@@ -37,6 +38,27 @@ class TestCosineSimilarity:
         z = np.zeros(3, dtype=np.float32)
         assert cosine_similarity(a, z) == pytest.approx(0.0)
         assert cosine_similarity(z, a) == pytest.approx(0.0)
+
+
+class TestCosineDistance:
+    """cosine_distance のテスト。"""
+
+    def test_identical_vectors(self) -> None:
+        """同一ベクトル → 0.0。"""
+        v = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        assert cosine_distance(v, v) == pytest.approx(0.0, abs=1e-6)
+
+    def test_orthogonal_vectors(self) -> None:
+        """直交ベクトル → 1.0。"""
+        a = np.array([1.0, 0.0], dtype=np.float32)
+        b = np.array([0.0, 1.0], dtype=np.float32)
+        assert cosine_distance(a, b) == pytest.approx(1.0)
+
+    def test_opposite_vectors(self) -> None:
+        """逆向きベクトル → 2.0。"""
+        a = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+        b = np.array([-1.0, -2.0, -3.0], dtype=np.float32)
+        assert cosine_distance(a, b) == pytest.approx(2.0)
 
 
 class TestNormalizedEditDistance:

--- a/tests/test_passphrase_auth.py
+++ b/tests/test_passphrase_auth.py
@@ -85,12 +85,13 @@ class TestPassphraseAuthEnroller:
         enroller.add_sample(audio)
         result = enroller.enroll()
         np.testing.assert_array_equal(result.embedding.values, [1.0, 0.0, 0.0])
+        assert result.selected_index == 0
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_multiple_samples(
+    def test_enroll_multiple_samples_selects_medoid(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -98,21 +99,26 @@ class TestPassphraseAuthEnroller:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """複数サンプルで平均ベクトルが返る。"""
+        """複数サンプルでメドイド（他との距離合計が最小）が選択される。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
         mock_extract_sp.return_value = audio
+        # サンプル0,1は類似、サンプル2は離れている → メドイドはサンプル0
         mock_extract_emb.side_effect = [
             make_embedding([1.0, 0.0, 0.0]),
+            make_embedding([0.9, 0.1, 0.0]),
             make_embedding([0.0, 1.0, 0.0]),
         ]
 
         enroller = auth.create_enroller()
         enroller.add_sample(audio)
         enroller.add_sample(audio)
+        enroller.add_sample(audio)
         result = enroller.enroll()
-        np.testing.assert_array_almost_equal(result.embedding.values, [0.5, 0.5, 0.0])
+        # サンプル1がメドイド（サンプル0,2両方に近い）
+        assert result.selected_index == 1
+        np.testing.assert_array_almost_equal(result.embedding.values, [0.9, 0.1, 0.0])
 
     def test_enroll_no_samples_raises(self, auth: PassphraseAuth) -> None:
         """サンプル未蓄積で ValueError。"""
@@ -166,6 +172,7 @@ class TestPassphraseAuthEnroller:
         result = enroller.enroll()
         assert isinstance(result, EnrollmentResult)
         assert isinstance(result.embedding, Embedding)
+        assert result.selected_index == 0
 
     def test_create_enroller_returns_correct_type(self, auth: PassphraseAuth) -> None:
         """create_enroller が PassphraseAuthEnroller を返す。"""
@@ -363,6 +370,7 @@ class TestPassphraseAuthPhonemes:
         result = enroller.enroll()
         assert isinstance(result, EnrollmentResult)
         assert result.phoneme.values == ["a", "i", "u", "e", "o"]
+        assert result.selected_index in range(3)
 
     @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
     @patch("voice_auth_engine.passphrase_auth.transcribe")
@@ -429,6 +437,7 @@ class TestPassphraseAuthPhonemes:
         enroller.add_sample(audio)
         result = enroller.enroll()
         assert result.phoneme.values == []
+        assert result.selected_index == 0
 
 
 class TestPassphraseAuthVerifierPhonemes:

--- a/tests/test_passphrase_auth_integration.py
+++ b/tests/test_passphrase_auth_integration.py
@@ -131,6 +131,7 @@ class TestPhonemeVerificationIntegration:
 
         assert enroller.sample_count == 3
         assert len(result.phoneme.values) > 0
+        assert result.selected_index in range(3)
 
     def test_same_speaker_same_passphrase_accepted(
         self,


### PR DESCRIPTION
## 概要

`PassphraseAuthEnroller.enroll()` の登録ロジックを、全サンプルの平均 embedding を算出する方式から、コサイン距離ベースのメドイド（最適な1サンプル）を選択する方式に変更する。

### 変更内容

- `enroll()` で `np.mean()` による平均 embedding 算出を削除し、コサイン距離ベースの medoid 選択に置き換え
- `EnrollmentResult` に `selected_index` フィールドを追加（選択されたサンプルのインデックス）
- `math.py` に `cosine_distance()` 関数を追加
- `pairwise_distances()` の型シグネチャを汎用化し、ndarray にも対応

### 背景

voice-auth-app 側の enroll フローでは、複数の登録音声から最も良質な1つを選択し確定する設計になっている。平均 embedding では「どの Voice が選ばれたか」を app 側に伝えられないため、medoid 選択方式に変更する。

Closes #71