### PR TITLE
refactor(passphrase_auth): remove Enroller/Verifier and make PassphraseAuth stateless

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -30,9 +30,7 @@ from voice_auth_engine.passphrase_auth import (
     EnrollmentResult,
     Passphrase,
     PassphraseAuth,
-    PassphraseAuthEnroller,
     PassphraseAuthError,
-    PassphraseAuthVerifier,
     VerificationResult,
 )
 from voice_auth_engine.passphrase_validator import (
@@ -83,8 +81,6 @@ __all__ = [
     "InsufficientPhonemeError",
     "PassphraseAuth",
     "PassphraseAuthError",
-    "PassphraseAuthEnroller",
-    "PassphraseAuthVerifier",
     "PhonemeConsistencyError",
     "Passphrase",
     "VerificationResult",

--- a/src/voice_auth_engine/passphrase_auth.py
+++ b/src/voice_auth_engine/passphrase_auth.py
@@ -53,25 +53,21 @@ class VerificationResult(NamedTuple):
 class PassphraseAuth:
     """パスフレーズ方式の話者認証。
 
-    Enroller と Verifier を生成し、
     音声読み込み → VAD → 発話時間チェック → 音素検証 → 埋め込み抽出の
-    共通パイプラインを提供する。
+    パイプラインと、登録・照合メソッドを提供する。
 
     使用例::
 
         auth = PassphraseAuth(threshold=0.5)
 
         # 登録
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio_bytes_1)
-        enroller.add_audio(audio_bytes_2)
-        embedding = enroller.enroll()
-        saved = embedding.to_bytes()
+        passphrases = [auth.extract_passphrase(a) for a in audios]
+        result = auth.enroll(passphrases)
+        saved = result.embedding.to_bytes()
 
         # 認証
-        embedding = Embedding.from_bytes(saved)
-        verifier = auth.create_verifier(embedding)
-        result = verifier.verify(audio_bytes)
+        passphrase = auth.extract_passphrase(audio_bytes)
+        result = auth.verify_passphrase(passphrase, enrollment)
         result.voiceprint_accepted  # True/False
         result.voiceprint_score     # 0.85
     """
@@ -104,20 +100,59 @@ class PassphraseAuth:
         """照合の閾値（コサイン類似度）。"""
         return self._threshold
 
-    def create_enroller(self) -> PassphraseAuthEnroller:
-        """登録用 Enroller を生成する。"""
-        return PassphraseAuthEnroller(self)
-
-    def create_verifier(
-        self, embedding: Embedding, phoneme: Phoneme | None = None
-    ) -> PassphraseAuthVerifier:
-        """照合用 Verifier を生成する。
+    def enroll_passphrase(self, passphrases: list[Passphrase]) -> EnrollmentResult:
+        """抽出済みパスフレーズから平均埋め込みベクトルと基準音素列を算出する。
 
         Args:
-            embedding: 登録済み埋め込みベクトル。
-            phoneme: 登録済み基準音素。None の場合は音素照合を無効化。
+            passphrases: extract_passphrase() で抽出済みのパスフレーズのリスト。
+
+        Returns:
+            平均埋め込みベクトルと基準音素列。
+
+        Raises:
+            ValueError: passphrases が空の場合。
+            PhonemeConsistencyError: 音素列の整合性チェックに失敗した場合。
         """
-        return PassphraseAuthVerifier(self, embedding, phoneme)
+        if not passphrases:
+            raise ValueError("passphrases が空です")
+        mean_values = np.mean([p.embedding.values for p in passphrases], axis=0)
+        embedding = Embedding(values=mean_values)
+        phoneme_samples = [p.phoneme for p in passphrases]
+        if self._phoneme_threshold is not None:
+            validate_phoneme_consistency(phoneme_samples, threshold=self._phoneme_threshold)
+            phoneme = Phoneme.select_reference(phoneme_samples)
+        else:
+            phoneme = Phoneme(values=[])
+        return EnrollmentResult(embedding=embedding, phoneme=phoneme)
+
+    def verify_passphrase(
+        self,
+        passphrase: Passphrase,
+        enrollment: EnrollmentResult,
+    ) -> VerificationResult:
+        """抽出済みパスフレーズを登録済み声紋と照合する。
+
+        Args:
+            passphrase: extract_passphrase() で抽出済みのパスフレーズ。
+            enrollment: select_passphrase() で算出した登録結果。
+        """
+        score = cosine_similarity(enrollment.embedding.values, passphrase.embedding.values)
+        speaker_accepted = score >= self._threshold
+
+        if self._phoneme_threshold is not None:
+            passphrase_score = normalized_edit_distance(
+                enrollment.phoneme.values, passphrase.phoneme.values
+            )
+            passphrase_accepted = passphrase_score <= self._phoneme_threshold
+            voiceprint_accepted = speaker_accepted and passphrase_accepted
+            return VerificationResult(
+                voiceprint_accepted=voiceprint_accepted,
+                voiceprint_score=score,
+                passphrase_score=passphrase_score,
+                passphrase_accepted=passphrase_accepted,
+            )
+
+        return VerificationResult(voiceprint_accepted=speaker_accepted, voiceprint_score=score)
 
     def extract_passphrase(self, audio: AudioInput) -> Passphrase:
         """音声入力から検証済み埋め込みベクトルと音素列を抽出する。
@@ -171,99 +206,3 @@ class PassphraseAuth:
             InsufficientPhonemeError: 音素多様性が不足の場合。
         """
         return self.extract_passphrase(audio).embedding
-
-
-class PassphraseAuthEnroller:
-    """声紋登録 (Enroller)。
-
-    音声サンプルを蓄積し、平均埋め込みベクトルと基準音素列を算出する。
-    ``PassphraseAuth.create_enroller()`` から生成する。
-    """
-
-    def __init__(self, auth: PassphraseAuth) -> None:
-        self._auth = auth
-        self._passphrases: list[Passphrase] = []
-
-    def add_audio(self, audio: AudioInput) -> None:
-        """音声サンプルを蓄積する。
-
-        Args:
-            audio: 登録用音声データ。
-
-        Raises:
-            EmptyAudioError: 音声区間が検出されなかった場合。
-            InsufficientDurationError: 発話時間が不足の場合。
-            InsufficientPhonemeError: 音素多様性が不足の場合。
-        """
-        result = self._auth.extract_passphrase(audio)
-        self._passphrases.append(result)
-
-    def enroll(self) -> EnrollmentResult:
-        """蓄積サンプルの平均埋め込みベクトルと基準音素列を返す。
-
-        Raises:
-            ValueError: サンプルが蓄積されていない場合。
-            PassphraseEnrollmentError: 音素列の整合性チェックに失敗した場合。
-        """
-        if not self._passphrases:
-            raise ValueError("サンプルが蓄積されていません")
-        mean_values = np.mean([p.embedding.values for p in self._passphrases], axis=0)
-        embedding = Embedding(values=mean_values)
-        phoneme_samples = [p.phoneme for p in self._passphrases]
-        if self._auth._phoneme_threshold is not None:
-            validate_phoneme_consistency(phoneme_samples, threshold=self._auth._phoneme_threshold)
-            phoneme = Phoneme.select_reference(phoneme_samples)
-        else:
-            phoneme = Phoneme(values=[])
-        return EnrollmentResult(embedding=embedding, phoneme=phoneme)
-
-    @property
-    def sample_count(self) -> int:
-        """蓄積済みサンプル数。"""
-        return len(self._passphrases)
-
-
-class PassphraseAuthVerifier:
-    """声紋照合 (Verifier)。
-
-    登録済み埋め込みベクトルに対して音声を照合する。
-    ``PassphraseAuth.create_verifier(embedding)`` から生成する。
-    """
-
-    def __init__(
-        self,
-        auth: PassphraseAuth,
-        embedding: Embedding,
-        phoneme: Phoneme | None = None,
-    ) -> None:
-        self._auth = auth
-        self._embedding = embedding
-        self._phoneme = phoneme
-
-    def verify(self, audio: AudioInput) -> VerificationResult:
-        """音声を登録済み声紋と照合する。
-
-        Args:
-            audio: 照合用音声データ。
-
-        Raises:
-            EmptyAudioError: 音声区間が検出されなかった場合。
-            InsufficientDurationError: 発話時間が不足の場合。
-            InsufficientPhonemeError: 音素多様性が不足の場合。
-        """
-        result = self._auth.extract_passphrase(audio)
-        score = cosine_similarity(self._embedding.values, result.embedding.values)
-        speaker_accepted = score >= self._auth.threshold
-
-        if self._phoneme is not None and self._auth._phoneme_threshold is not None:
-            passphrase_score = normalized_edit_distance(self._phoneme.values, result.phoneme.values)
-            passphrase_accepted = passphrase_score <= self._auth._phoneme_threshold
-            voiceprint_accepted = speaker_accepted and passphrase_accepted
-            return VerificationResult(
-                voiceprint_accepted=voiceprint_accepted,
-                voiceprint_score=score,
-                passphrase_score=passphrase_score,
-                passphrase_accepted=passphrase_accepted,
-            )
-
-        return VerificationResult(voiceprint_accepted=speaker_accepted, voiceprint_score=score)

--- a/tests/test_passphrase_auth.py
+++ b/tests/test_passphrase_auth.py
@@ -14,8 +14,6 @@ from voice_auth_engine.passphrase_auth import (
     EnrollmentResult,
     Passphrase,
     PassphraseAuth,
-    PassphraseAuthEnroller,
-    PassphraseAuthVerifier,
 )
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 from voice_auth_engine.phoneme_extractor import Phoneme
@@ -33,34 +31,8 @@ def auth() -> PassphraseAuth:
     )
 
 
-class TestPassphraseAuthEnroller:
-    """PassphraseAuthEnroller のテスト。"""
-
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_add_audio_increments_count(
-        self,
-        mock_extract_emb: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_load: MagicMock,
-        auth: PassphraseAuth,
-    ) -> None:
-        """add_audio 後に sample_count が増加する。"""
-        audio = make_audio(1.0)
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
-
-        enroller = auth.create_enroller()
-        assert enroller.sample_count == 0
-        enroller.add_audio(audio)
-        assert enroller.sample_count == 1
-        enroller.add_audio(audio)
-        assert enroller.sample_count == 2
+class TestEnrollPassphrase:
+    """PassphraseAuth.enroll_passphrase のテスト。"""
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
@@ -81,9 +53,8 @@ class TestPassphraseAuthEnroller:
         mock_extract_sp.return_value = audio
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio)
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(audio)]
+        result = auth.enroll_passphrase(passphrases)
         np.testing.assert_array_equal(result.embedding.values, [1.0, 0.0, 0.0])
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
@@ -108,22 +79,19 @@ class TestPassphraseAuthEnroller:
             make_embedding([0.0, 1.0, 0.0]),
         ]
 
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio)
-        enroller.add_audio(audio)
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(audio) for _ in range(2)]
+        result = auth.enroll_passphrase(passphrases)
         np.testing.assert_array_almost_equal(result.embedding.values, [0.5, 0.5, 0.0])
 
-    def test_enroll_no_samples_raises(self, auth: PassphraseAuth) -> None:
-        """サンプル未蓄積で ValueError。"""
-        enroller = auth.create_enroller()
-        with pytest.raises(ValueError, match="サンプルが蓄積されていません"):
-            enroller.enroll()
+    def test_enroll_empty_raises(self, auth: PassphraseAuth) -> None:
+        """空リストで ValueError。"""
+        with pytest.raises(ValueError, match="passphrases が空です"):
+            auth.enroll_passphrase([])
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    def test_add_audio_no_speech_raises(
+    def test_enroll_no_speech_raises(
         self,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
@@ -138,15 +106,14 @@ class TestPassphraseAuthEnroller:
             samples=np.array([], dtype=np.int16), sample_rate=16000
         )
 
-        enroller = auth.create_enroller()
         with pytest.raises(EmptyAudioError):
-            enroller.add_audio(audio)
+            auth.extract_passphrase(audio)
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_returns_embedding(
+    def test_enroll_returns_enrollment_result(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -154,110 +121,59 @@ class TestPassphraseAuthEnroller:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """enroll() が Embedding を返す。"""
+        """enroll() が EnrollmentResult を返す。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
         mock_extract_sp.return_value = audio
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio)
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(audio)]
+        result = auth.enroll_passphrase(passphrases)
         assert isinstance(result, EnrollmentResult)
         assert isinstance(result.embedding, Embedding)
 
-    def test_create_enroller_returns_correct_type(self, auth: PassphraseAuth) -> None:
-        """create_enroller が PassphraseAuthEnroller を返す。"""
-        enroller = auth.create_enroller()
-        assert isinstance(enroller, PassphraseAuthEnroller)
 
+class TestVerifyPassphrase:
+    """PassphraseAuth.verify_passphrase のテスト。"""
 
-class TestPassphraseAuthVerifier:
-    """PassphraseAuthVerifier のテスト。"""
-
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_verify_accepted(
-        self,
-        mock_extract_emb: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_load: MagicMock,
-        auth: PassphraseAuth,
-    ) -> None:
+    def test_verify_accepted(self, auth: PassphraseAuth) -> None:
         """類似度 >= threshold で accepted=True。"""
-        audio = make_audio(1.0)
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
+        )
 
-        verifier = auth.create_verifier(enrolled)
-        result = verifier.verify(audio)
+        result = auth.verify_passphrase(passphrase, enrollment)
         assert result.voiceprint_accepted is True
         assert result.voiceprint_score == pytest.approx(1.0)
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_verify_rejected(
-        self,
-        mock_extract_emb: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_load: MagicMock,
-        auth: PassphraseAuth,
-    ) -> None:
+    def test_verify_rejected(self, auth: PassphraseAuth) -> None:
         """類似度 < threshold で accepted=False。"""
-        audio = make_audio(1.0)
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([0.0, 1.0, 0.0])
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([0.0, 1.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
+        )
 
-        verifier = auth.create_verifier(enrolled)
-        result = verifier.verify(audio)
+        result = auth.verify_passphrase(passphrase, enrollment)
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score == pytest.approx(0.0)
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    def test_verify_no_speech_raises(
-        self,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_load: MagicMock,
-        auth: PassphraseAuth,
-    ) -> None:
-        """VAD で音声なしの場合 EmptyAudioError。"""
-        audio = make_audio(1.0)
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio, empty=True)
-        mock_extract_sp.return_value = AudioData(
-            samples=np.array([], dtype=np.int16), sample_rate=16000
-        )
 
-        verifier = auth.create_verifier(enrolled)
-        with pytest.raises(EmptyAudioError):
-            verifier.verify(audio)
-
-    def test_create_verifier_returns_correct_type(self, auth: PassphraseAuth) -> None:
-        """create_verifier が PassphraseAuthVerifier を返す。"""
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        verifier = auth.create_verifier(enrolled)
-        assert isinstance(verifier, PassphraseAuthVerifier)
-
-
-class TestPassphraseAuthPhonemes:
-    """音素収集・メドイド選択・整合性チェックのテスト。"""
+class TestEnrollPassphrasePhonemes:
+    """enroll_passphrase の音素収集・メドイド選択・整合性チェックのテスト。"""
 
     @pytest.fixture
     def auth_with_phonemes(self) -> PassphraseAuth:
@@ -357,10 +273,8 @@ class TestPassphraseAuthPhonemes:
             mock_extract_phonemes,
             phoneme_lists=phoneme_lists,
         )
-        enroller = auth_with_phonemes.create_enroller()
-        for _ in range(3):
-            enroller.add_audio(audio)
-        result = enroller.enroll()
+        passphrases = [auth_with_phonemes.extract_passphrase(audio) for _ in range(3)]
+        result = auth_with_phonemes.enroll_passphrase(passphrases)
         assert isinstance(result, EnrollmentResult)
         assert result.phoneme.values == ["a", "i", "u", "e", "o"]
 
@@ -400,11 +314,9 @@ class TestPassphraseAuthPhonemes:
             mock_extract_phonemes,
             phoneme_lists=phoneme_lists,
         )
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio)
-        enroller.add_audio(audio)
+        passphrases = [auth.extract_passphrase(audio) for _ in range(2)]
         with pytest.raises(PhonemeConsistencyError, match="音素列の不整合"):
-            enroller.enroll()
+            auth.enroll_passphrase(passphrases)
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
@@ -425,14 +337,13 @@ class TestPassphraseAuthPhonemes:
         mock_extract_sp.return_value = audio
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
-        enroller = auth.create_enroller()
-        enroller.add_audio(audio)
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(audio)]
+        result = auth.enroll_passphrase(passphrases)
         assert result.phoneme.values == []
 
 
-class TestPassphraseAuthVerifierPhonemes:
-    """音素照合ゲート付き Verifier のテスト。"""
+class TestVerifyPassphrasePhonemes:
+    """verify_passphrase の音素照合ゲート付きテスト。"""
 
     @pytest.fixture
     def auth_with_phoneme_gate(self) -> PassphraseAuth:
@@ -444,137 +355,87 @@ class TestPassphraseAuthVerifierPhonemes:
             phoneme_threshold=0.3,
         )
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
     def test_phoneme_match_accepted(
         self,
-        mock_load: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_extract_emb: MagicMock,
-        mock_transcribe: MagicMock,
-        mock_extract_phonemes: MagicMock,
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者一致 + 音素一致で accepted=True。"""
-        audio = make_audio(1.0)
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
-        mock_transcribe.return_value = MagicMock(text="test")
-        mock_extract_phonemes.return_value = Phoneme(
-            values=["a", "i", "u", "e", "o"],
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+            transcription="test",
+            speech_duration=1.0,
         )
 
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
-        verifier = auth_with_phoneme_gate.create_verifier(enrolled, phoneme)
-        result = verifier.verify(audio)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_accepted is True
         assert result.passphrase_score == pytest.approx(0.0)
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
     def test_phoneme_mismatch_rejected(
         self,
-        mock_load: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_extract_emb: MagicMock,
-        mock_transcribe: MagicMock,
-        mock_extract_phonemes: MagicMock,
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者一致 + 音素不一致で accepted=False。"""
-        audio = make_audio(1.0)
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
-        mock_transcribe.return_value = MagicMock(text="test")
-        mock_extract_phonemes.return_value = Phoneme(
-            values=["k", "a", "k", "i", "k"],
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=["k", "a", "k", "i", "k"]),
+            transcription="test",
+            speech_duration=1.0,
         )
 
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
-        verifier = auth_with_phoneme_gate.create_verifier(enrolled, phoneme)
-        result = verifier.verify(audio)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is False
         assert result.passphrase_accepted is False
         assert result.passphrase_score is not None
         assert result.passphrase_score > 0.3
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
     def test_speaker_mismatch_with_phoneme_match_rejected(
         self,
-        mock_load: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_extract_emb: MagicMock,
-        mock_transcribe: MagicMock,
-        mock_extract_phonemes: MagicMock,
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者不一致 + 音素一致でも accepted=False。"""
-        audio = make_audio(1.0)
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([0.0, 1.0, 0.0])
-        mock_transcribe.return_value = MagicMock(text="test")
-        mock_extract_phonemes.return_value = Phoneme(
-            values=["a", "i", "u", "e", "o"],
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([0.0, 1.0, 0.0]),
+            phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+            transcription="test",
+            speech_duration=1.0,
         )
 
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
-        verifier = auth_with_phoneme_gate.create_verifier(enrolled, phoneme)
-        result = verifier.verify(audio)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is False
         assert result.passphrase_accepted is True
         assert result.voiceprint_score == pytest.approx(0.0)
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_phonemes_none_backward_compat(
-        self,
-        mock_extract_emb: MagicMock,
-        mock_detect: MagicMock,
-        mock_extract_sp: MagicMock,
-        mock_load: MagicMock,
-        auth: PassphraseAuth,
-    ) -> None:
-        """phonemes=None で音素照合無効（後方互換）。"""
-        audio = make_audio(1.0)
-        mock_load.return_value = audio
-        mock_detect.return_value = make_segments(audio)
-        mock_extract_sp.return_value = audio
-        mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
+    def test_no_phoneme_threshold_skips_passphrase_check(self, auth: PassphraseAuth) -> None:
+        """phoneme_threshold=None で音素照合無効。"""
+        enrollment = EnrollmentResult(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+        )
+        passphrase = Passphrase(
+            embedding=make_embedding([1.0, 0.0, 0.0]),
+            phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
+        )
 
-        enrolled = make_embedding([1.0, 0.0, 0.0])
-        verifier = auth.create_verifier(enrolled)
-        result = verifier.verify(audio)
+        result = auth.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_score is None

--- a/tests/test_passphrase_auth_integration.py
+++ b/tests/test_passphrase_auth_integration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from voice_auth_engine.audio_validator import EmptyAudioError, InsufficientDurationError
-from voice_auth_engine.passphrase_auth import PassphraseAuth
+from voice_auth_engine.passphrase_auth import EnrollmentResult, PassphraseAuth
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 
 from .audio_factory import generate_silence_samples, make_audio_data
@@ -26,12 +26,11 @@ class TestPassphraseAuthIntegration:
 
     def test_enroll_and_verify_same_speaker(self, auth: PassphraseAuth) -> None:
         """登録→本人認証で accepted=True。"""
-        enroller = auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
+        enrollment = auth.enroll_passphrase(passphrases)
 
-        verifier = auth.create_verifier(result.embedding)
-        result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
+        passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
+        result = auth.verify_passphrase(passphrase, enrollment)
         assert result.voiceprint_accepted is True
         assert result.voiceprint_score > auth.threshold
 
@@ -41,12 +40,11 @@ class TestPassphraseAuthIntegration:
     )
     def test_reject_different_speaker(self, auth: PassphraseAuth, other_speaker: str) -> None:
         """登録→他人認証で accepted=False。"""
-        enroller = auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
+        enrollment = auth.enroll_passphrase(passphrases)
 
-        verifier = auth.create_verifier(result.embedding)
-        result = verifier.verify(FIXTURES_DIR / other_speaker)
+        passphrase = auth.extract_passphrase(FIXTURES_DIR / other_speaker)
+        result = auth.verify_passphrase(passphrase, enrollment)
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score < auth.threshold
 
@@ -58,43 +56,44 @@ class TestPassphraseAuthIntegration:
         self, auth: PassphraseAuth, other_speaker: str
     ) -> None:
         """本人のスコアが他人のスコアより高い。"""
-        enroller = auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        result = enroller.enroll()
+        passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
+        enrollment = auth.enroll_passphrase(passphrases)
 
-        verifier = auth.create_verifier(result.embedding)
-        same_result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
-        diff_result = verifier.verify(FIXTURES_DIR / other_speaker)
+        same_passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
+        diff_passphrase = auth.extract_passphrase(FIXTURES_DIR / other_speaker)
+        same_result = auth.verify_passphrase(same_passphrase, enrollment)
+        diff_result = auth.verify_passphrase(diff_passphrase, enrollment)
         assert same_result.voiceprint_score > diff_result.voiceprint_score
 
     def test_embedding_serialization_roundtrip(self, auth: PassphraseAuth) -> None:
         """埋め込みベクトルのシリアライズ→デシリアライズ後も認証可能。"""
         from voice_auth_engine.embedding_extractor import Embedding
 
-        enroller = auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_enroll.mp3")
-        enrollment = enroller.enroll()
+        passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
+        enrollment = auth.enroll_passphrase(passphrases)
 
         restored = Embedding.from_bytes(enrollment.embedding.to_bytes())
-        verifier = auth.create_verifier(restored)
-        result = verifier.verify(FIXTURES_DIR / "speaker_a_verify.mp3")
+        restored_enrollment = EnrollmentResult(
+            embedding=restored,
+            phoneme=enrollment.phoneme,
+        )
+        passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
+        result = auth.verify_passphrase(passphrase, restored_enrollment)
         assert result.voiceprint_accepted is True
 
     def test_silence_raises_empty_audio_error(self, auth: PassphraseAuth) -> None:
         """無音音声で EmptyAudioError が発生する。"""
         silence = make_audio_data(generate_silence_samples(duration=5.0))
-        enroller = auth.create_enroller()
         with pytest.raises(EmptyAudioError):
-            enroller.add_audio(silence)
+            auth.extract_passphrase(silence)
 
     def test_short_speech_raises_insufficient_duration_error(
         self,
         auth: PassphraseAuth,
     ) -> None:
         """発話時間が短い音声で InsufficientDurationError が発生する。"""
-        enroller = auth.create_enroller()
         with pytest.raises(InsufficientDurationError):
-            enroller.add_audio(FIXTURES_DIR / "digits_clear.mp3")
+            auth.extract_passphrase(FIXTURES_DIR / "digits_clear.mp3")
 
 
 @pytest.fixture
@@ -111,10 +110,11 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """phoneme_threshold 有効で登録すると phonemes が返る。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")
-        result = enroller.enroll()
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
+        ]
+        result = phoneme_auth.enroll_passphrase(passphrases)
 
         assert len(result.phoneme.values) > 0
 
@@ -123,13 +123,13 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """3サンプル登録でメドイドが選択され phonemes が返る。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_3.mp3")
-        result = enroller.enroll()
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_3.mp3"),
+        ]
+        result = phoneme_auth.enroll_passphrase(passphrases)
 
-        assert enroller.sample_count == 3
         assert len(result.phoneme.values) > 0
 
     def test_same_speaker_same_passphrase_accepted(
@@ -137,13 +137,14 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """本人+同一パスフレーズで accepted=True, passphrase_accepted=True。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")
-        enrollment = enroller.enroll()
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
+        ]
+        enrollment = phoneme_auth.enroll_passphrase(passphrases)
 
-        verifier = phoneme_auth.create_verifier(enrollment.embedding, enrollment.phoneme)
-        result = verifier.verify(FIXTURES_DIR / "speaker_a_phrase_a_verify.mp3")
+        passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_verify.mp3")
+        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_accepted is True
@@ -156,13 +157,14 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """本人+異なるパスフレーズで accepted=False（話者OK, 音素NG）。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")
-        enrollment = enroller.enroll()
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
+        ]
+        enrollment = phoneme_auth.enroll_passphrase(passphrases)
 
-        verifier = phoneme_auth.create_verifier(enrollment.embedding, enrollment.phoneme)
-        result = verifier.verify(FIXTURES_DIR / "speaker_a_phrase_b.mp3")
+        passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_b.mp3")
+        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score >= phoneme_auth.threshold  # 話者は本人
@@ -173,13 +175,14 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """他人+同一パスフレーズで accepted=False（話者NG, 音素OK）。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")
-        enrollment = enroller.enroll()
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
+        ]
+        enrollment = phoneme_auth.enroll_passphrase(passphrases)
 
-        verifier = phoneme_auth.create_verifier(enrollment.embedding, enrollment.phoneme)
-        result = verifier.verify(FIXTURES_DIR / "speaker_b_phrase_a.mp3")
+        passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_b_phrase_a.mp3")
+        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score < phoneme_auth.threshold  # 話者が異なる
@@ -190,9 +193,9 @@ class TestPhonemeVerificationIntegration:
         phoneme_auth: PassphraseAuth,
     ) -> None:
         """異なるパスフレーズで登録すると PhonemeConsistencyError。"""
-        enroller = phoneme_auth.create_enroller()
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")
-        enroller.add_audio(FIXTURES_DIR / "speaker_a_phrase_b.mp3")
-
+        passphrases = [
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
+            phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_b.mp3"),
+        ]
         with pytest.raises(PhonemeConsistencyError):
-            enroller.enroll()
+            phoneme_auth.enroll_passphrase(passphrases)


### PR DESCRIPTION
## 概要

`PassphraseAuthEnroller` と `PassphraseAuthVerifier` クラスを削除し、`PassphraseAuth` に `enroll_passphrase()` / `verify_passphrase()` メソッドとして統合するリファクタリング。

内部状態を持たないステートレス設計に変更し、抽出・登録・照合の各ステップを分離した。

### 変更内容

- `PassphraseAuthEnroller` クラスを削除 → `enroll_passphrase(passphrases: list[Passphrase])` に統合
- `PassphraseAuthVerifier` クラスを削除 → `verify_passphrase(passphrase: Passphrase, enrollment: EnrollmentResult)` に統合
- `create_enroller()` / `create_verifier()` ファクトリメソッドを削除
- `__init__.py` から `PassphraseAuthEnroller` / `PassphraseAuthVerifier` のエクスポートを削除
- テストを新しいステートレスAPIに対応

### 新しいAPI

```python
auth = PassphraseAuth(threshold=0.5)

# 登録
passphrases = [auth.extract_passphrase(a) for a in audios]
enrollment = auth.enroll_passphrase(passphrases)

# 認証
passphrase = auth.extract_passphrase(audio)
result = auth.verify_passphrase(passphrase, enrollment)
```