### PR TITLE
refactor(passphrase_auth): replace mean embedding with medoid selection

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -27,7 +27,6 @@ from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 from voice_auth_engine.model_config import ModelConfig
 from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
 from voice_auth_engine.passphrase_auth import (
-    EnrollmentResult,
     Passphrase,
     PassphraseAuth,
     PassphraseAuthError,
@@ -74,7 +73,6 @@ __all__ = [
     "EmbeddingModelLoadError",
     "EmptyAudioError",
     "EmptyPassphraseError",
-    "EnrollmentResult",
     "ModelDownloadError",
     "ModelDownloader",
     "InsufficientDurationError",

--- a/src/voice_auth_engine/math.py
+++ b/src/voice_auth_engine/math.py
@@ -69,6 +69,26 @@ def normalized_edit_distance(a: Sequence[T], b: Sequence[T]) -> float:
     return prev[len_a] / max(len_a, len_b)
 
 
+def cosine_distance_matrix(
+    vectors: Sequence[npt.NDArray[np.float32]],
+) -> list[list[float]]:
+    """コサイン距離の全ペア距離行列を計算する。
+
+    cosine_distance = 1 - cosine_similarity。
+
+    Returns:
+        n×n の対称行列。matrix[i][j] は vectors[i] と vectors[j] のコサイン距離。
+    """
+    n = len(vectors)
+    distances = [[0.0] * n for _ in range(n)]
+    for i in range(n):
+        for j in range(i + 1, n):
+            d = 1.0 - cosine_similarity(vectors[i], vectors[j])
+            distances[i][j] = d
+            distances[j][i] = d
+    return distances
+
+
 def pairwise_distances(
     sequences: Sequence[Sequence[T]],
     distance_fn: Callable[[Sequence[T], Sequence[T]], float] = normalized_edit_distance,

--- a/src/voice_auth_engine/passphrase_auth.py
+++ b/src/voice_auth_engine/passphrase_auth.py
@@ -5,12 +5,15 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import NamedTuple
 
-import numpy as np
-
 from voice_auth_engine.audio_preprocessor import AudioInput, load_audio
 from voice_auth_engine.audio_validator import validate_audio
 from voice_auth_engine.embedding_extractor import Embedding, extract_embedding
-from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
+from voice_auth_engine.math import (
+    cosine_distance_matrix,
+    cosine_similarity,
+    normalized_edit_distance,
+    select_medoid,
+)
 from voice_auth_engine.passphrase_validator import (
     validate_passphrase,
     validate_phoneme_consistency,
@@ -34,13 +37,6 @@ class Passphrase:
     speech_duration: float  # VAD後の発話区間の長さ（秒）
 
 
-class EnrollmentResult(NamedTuple):
-    """登録結果。"""
-
-    embedding: Embedding
-    phoneme: Phoneme  # 基準音素（メドイドで決定）
-
-
 class VerificationResult(NamedTuple):
     """照合結果。"""
 
@@ -54,7 +50,7 @@ class PassphraseAuth:
     """パスフレーズ方式の話者認証。
 
     音声読み込み → VAD → 発話時間チェック → 音素検証 → 埋め込み抽出の
-    パイプラインと、登録・照合メソッドを提供する。
+    パイプラインと、選択・照合メソッドを提供する。
 
     使用例::
 
@@ -62,12 +58,12 @@ class PassphraseAuth:
 
         # 登録
         passphrases = [auth.extract_passphrase(a) for a in audios]
-        result = auth.enroll(passphrases)
-        saved = result.embedding.to_bytes()
+        selected, index = auth.select_passphrase(passphrases)
+        saved = selected.embedding.to_bytes()
 
         # 認証
         passphrase = auth.extract_passphrase(audio_bytes)
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, selected)
         result.voiceprint_accepted  # True/False
         result.voiceprint_score     # 0.85
     """
@@ -100,14 +96,17 @@ class PassphraseAuth:
         """照合の閾値（コサイン類似度）。"""
         return self._threshold
 
-    def enroll_passphrase(self, passphrases: list[Passphrase]) -> EnrollmentResult:
-        """抽出済みパスフレーズから平均埋め込みベクトルと基準音素列を算出する。
+    def select_passphrase(self, passphrases: list[Passphrase]) -> tuple[Passphrase, int]:
+        """抽出済みパスフレーズから最適な1サンプルを選択する。
+
+        embedding のコサイン距離に基づく medoid 選択で、他サンプルとの距離の
+        総和が最小のサンプルを選ぶ。サンプルが1つの場合はそのまま返す。
 
         Args:
             passphrases: extract_passphrase() で抽出済みのパスフレーズのリスト。
 
         Returns:
-            平均埋め込みベクトルと基準音素列。
+            選択されたパスフレーズとそのインデックス。
 
         Raises:
             ValueError: passphrases が空の場合。
@@ -115,33 +114,33 @@ class PassphraseAuth:
         """
         if not passphrases:
             raise ValueError("passphrases が空です")
-        mean_values = np.mean([p.embedding.values for p in passphrases], axis=0)
-        embedding = Embedding(values=mean_values)
         phoneme_samples = [p.phoneme for p in passphrases]
         if self._phoneme_threshold is not None:
             validate_phoneme_consistency(phoneme_samples, threshold=self._phoneme_threshold)
-            phoneme = Phoneme.select_reference(phoneme_samples)
-        else:
-            phoneme = Phoneme(values=[])
-        return EnrollmentResult(embedding=embedding, phoneme=phoneme)
+        if len(passphrases) == 1:
+            return passphrases[0], 0
+        vectors = [p.embedding.values for p in passphrases]
+        distances = cosine_distance_matrix(vectors)
+        index = select_medoid(distances)
+        return passphrases[index], index
 
     def verify_passphrase(
         self,
         passphrase: Passphrase,
-        enrollment: EnrollmentResult,
+        enrolled: Passphrase,
     ) -> VerificationResult:
         """抽出済みパスフレーズを登録済み声紋と照合する。
 
         Args:
             passphrase: extract_passphrase() で抽出済みのパスフレーズ。
-            enrollment: select_passphrase() で算出した登録結果。
+            enrolled: select_passphrase() で選択された登録済みパスフレーズ。
         """
-        score = cosine_similarity(enrollment.embedding.values, passphrase.embedding.values)
+        score = cosine_similarity(enrolled.embedding.values, passphrase.embedding.values)
         speaker_accepted = score >= self._threshold
 
         if self._phoneme_threshold is not None:
             passphrase_score = normalized_edit_distance(
-                enrollment.phoneme.values, passphrase.phoneme.values
+                enrolled.phoneme.values, passphrase.phoneme.values
             )
             passphrase_accepted = passphrase_score <= self._phoneme_threshold
             voiceprint_accepted = speaker_accepted and passphrase_accepted

--- a/tests/test_math.py
+++ b/tests/test_math.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 
 from voice_auth_engine.math import (
+    cosine_distance_matrix,
     cosine_similarity,
     normalized_edit_distance,
     pairwise_distances,
@@ -67,6 +68,42 @@ class TestNormalizedEditDistance:
         a = ["a", "b", "c"]
         b = ["x", "y", "z"]
         assert normalized_edit_distance(a, b) == pytest.approx(1.0)
+
+
+class TestCosineDistanceMatrix:
+    """cosine_distance_matrix のテスト。"""
+
+    def test_identical_vectors(self) -> None:
+        """同一ベクトル同士 → 距離 0.0。"""
+        v = np.array([1.0, 0.0, 0.0], dtype=np.float32)
+        result = cosine_distance_matrix([v, v])
+        assert result[0][1] == pytest.approx(0.0)
+
+    def test_orthogonal_vectors(self) -> None:
+        """直交ベクトル → 距離 1.0。"""
+        a = np.array([1.0, 0.0], dtype=np.float32)
+        b = np.array([0.0, 1.0], dtype=np.float32)
+        result = cosine_distance_matrix([a, b])
+        assert result[0][1] == pytest.approx(1.0)
+
+    def test_symmetric(self) -> None:
+        """距離行列が対称であること。"""
+        vectors = [
+            np.array([1.0, 0.0, 0.0], dtype=np.float32),
+            np.array([0.9, 0.1, 0.0], dtype=np.float32),
+            np.array([0.0, 0.0, 1.0], dtype=np.float32),
+        ]
+        result = cosine_distance_matrix(vectors)
+        for i in range(3):
+            assert result[i][i] == pytest.approx(0.0)
+            for j in range(3):
+                assert result[i][j] == pytest.approx(result[j][i])
+
+    def test_single_vector(self) -> None:
+        """単一ベクトル → 1×1 のゼロ行列。"""
+        v = np.array([1.0, 0.0], dtype=np.float32)
+        result = cosine_distance_matrix([v])
+        assert result == [[0.0]]
 
 
 class TestPairwiseDistances:

--- a/tests/test_passphrase_auth.py
+++ b/tests/test_passphrase_auth.py
@@ -11,7 +11,6 @@ from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.audio_validator import EmptyAudioError
 from voice_auth_engine.embedding_extractor import Embedding
 from voice_auth_engine.passphrase_auth import (
-    EnrollmentResult,
     Passphrase,
     PassphraseAuth,
 )
@@ -31,14 +30,14 @@ def auth() -> PassphraseAuth:
     )
 
 
-class TestEnrollPassphrase:
-    """PassphraseAuth.enroll_passphrase のテスト。"""
+class TestSelectPassphrase:
+    """PassphraseAuth.select_passphrase のテスト。"""
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_single_sample(
+    def test_single_sample(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -46,7 +45,7 @@ class TestEnrollPassphrase:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """1サンプルで正常に登録できる。"""
+        """1サンプルでそのまま返る。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
@@ -54,14 +53,16 @@ class TestEnrollPassphrase:
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
         passphrases = [auth.extract_passphrase(audio)]
-        result = auth.enroll_passphrase(passphrases)
-        np.testing.assert_array_equal(result.embedding.values, [1.0, 0.0, 0.0])
+        selected, index = auth.select_passphrase(passphrases)
+        assert index == 0
+        assert selected is passphrases[0]
+        np.testing.assert_array_equal(selected.embedding.values, [1.0, 0.0, 0.0])
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_multiple_samples(
+    def test_multiple_samples_selects_medoid(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -69,29 +70,32 @@ class TestEnrollPassphrase:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """複数サンプルで平均ベクトルが返る。"""
+        """複数サンプルで medoid が選択される。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
         mock_extract_sp.return_value = audio
+        # サンプル0,1は近く、サンプル2は遠い → medoid はサンプル0またはサンプル1
         mock_extract_emb.side_effect = [
             make_embedding([1.0, 0.0, 0.0]),
-            make_embedding([0.0, 1.0, 0.0]),
+            make_embedding([0.9, 0.1, 0.0]),
+            make_embedding([0.0, 0.0, 1.0]),
         ]
 
-        passphrases = [auth.extract_passphrase(audio) for _ in range(2)]
-        result = auth.enroll_passphrase(passphrases)
-        np.testing.assert_array_almost_equal(result.embedding.values, [0.5, 0.5, 0.0])
+        passphrases = [auth.extract_passphrase(audio) for _ in range(3)]
+        selected, index = auth.select_passphrase(passphrases)
+        assert index in (0, 1)
+        assert selected is passphrases[index]
 
-    def test_enroll_empty_raises(self, auth: PassphraseAuth) -> None:
+    def test_empty_raises(self, auth: PassphraseAuth) -> None:
         """空リストで ValueError。"""
         with pytest.raises(ValueError, match="passphrases が空です"):
-            auth.enroll_passphrase([])
+            auth.select_passphrase([])
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    def test_enroll_no_speech_raises(
+    def test_extract_no_speech_raises(
         self,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
@@ -113,7 +117,7 @@ class TestEnrollPassphrase:
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_returns_enrollment_result(
+    def test_returns_passphrase_and_index(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -121,7 +125,7 @@ class TestEnrollPassphrase:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """enroll() が EnrollmentResult を返す。"""
+        """select_passphrase() が tuple[Passphrase, int] を返す。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
@@ -129,9 +133,9 @@ class TestEnrollPassphrase:
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
         passphrases = [auth.extract_passphrase(audio)]
-        result = auth.enroll_passphrase(passphrases)
-        assert isinstance(result, EnrollmentResult)
-        assert isinstance(result.embedding, Embedding)
+        selected, index = auth.select_passphrase(passphrases)
+        assert isinstance(selected, Passphrase)
+        assert isinstance(index, int)
 
 
 class TestVerifyPassphrase:
@@ -139,9 +143,11 @@ class TestVerifyPassphrase:
 
     def test_verify_accepted(self, auth: PassphraseAuth) -> None:
         """類似度 >= threshold で accepted=True。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -150,15 +156,17 @@ class TestVerifyPassphrase:
             speech_duration=1.0,
         )
 
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, enrolled)
         assert result.voiceprint_accepted is True
         assert result.voiceprint_score == pytest.approx(1.0)
 
     def test_verify_rejected(self, auth: PassphraseAuth) -> None:
         """類似度 < threshold で accepted=False。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([0.0, 1.0, 0.0]),
@@ -167,13 +175,13 @@ class TestVerifyPassphrase:
             speech_duration=1.0,
         )
 
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, enrolled)
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score == pytest.approx(0.0)
 
 
-class TestEnrollPassphrasePhonemes:
-    """enroll_passphrase の音素収集・メドイド選択・整合性チェックのテスト。"""
+class TestSelectPassphrasePhonemes:
+    """select_passphrase の音素整合性チェックのテスト。"""
 
     @pytest.fixture
     def auth_with_phonemes(self) -> PassphraseAuth:
@@ -195,13 +203,17 @@ class TestEnrollPassphrasePhonemes:
         mock_extract_phonemes: MagicMock,
         *,
         phoneme_lists: list[list[str]],
+        embedding_lists: list[list[float]] | None = None,
     ) -> AudioData:
         """共通モック設定。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
         mock_extract_sp.return_value = audio
-        mock_extract_emb.side_effect = [make_embedding([1.0, 0.0, 0.0]) for _ in phoneme_lists]
+        if embedding_lists is not None:
+            mock_extract_emb.side_effect = [make_embedding(e) for e in embedding_lists]
+        else:
+            mock_extract_emb.side_effect = [make_embedding([1.0, 0.0, 0.0]) for _ in phoneme_lists]
         mock_transcribe.side_effect = [
             MagicMock(text=f"text{i}") for i in range(len(phoneme_lists))
         ]
@@ -245,7 +257,7 @@ class TestEnrollPassphrasePhonemes:
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.load_audio")
-    def test_enroll_selects_medoid_phonemes(
+    def test_selects_medoid_by_embedding(
         self,
         mock_load: MagicMock,
         mock_detect: MagicMock,
@@ -255,14 +267,18 @@ class TestEnrollPassphrasePhonemes:
         mock_extract_phonemes: MagicMock,
         auth_with_phonemes: PassphraseAuth,
     ) -> None:
-        """enroll() がメドイドで選ばれた基準音素列を返す。"""
-        # サンプル0,1は同一、サンプル2は1箇所異なる
-        # d(0,1)=0.0, d(0,2)=0.2, d(1,2)=0.2
-        # メドイド: サンプル0（距離合計0.2、同率のサンプル1より先頭）
+        """select_passphrase() が embedding の medoid でサンプルを選択する。"""
+        # サンプル0,1は近い embedding、サンプル2は遠い
+        # → medoid はサンプル0またはサンプル1
         phoneme_lists = [
             ["a", "i", "u", "e", "o"],
             ["a", "i", "u", "e", "o"],
-            ["a", "i", "u", "e", "a"],
+            ["a", "i", "u", "e", "o"],
+        ]
+        embedding_lists = [
+            [1.0, 0.0, 0.0],
+            [0.9, 0.1, 0.0],
+            [0.0, 0.0, 1.0],
         ]
         audio = self._setup_mocks(
             mock_load,
@@ -272,11 +288,12 @@ class TestEnrollPassphrasePhonemes:
             mock_transcribe,
             mock_extract_phonemes,
             phoneme_lists=phoneme_lists,
+            embedding_lists=embedding_lists,
         )
         passphrases = [auth_with_phonemes.extract_passphrase(audio) for _ in range(3)]
-        result = auth_with_phonemes.enroll_passphrase(passphrases)
-        assert isinstance(result, EnrollmentResult)
-        assert result.phoneme.values == ["a", "i", "u", "e", "o"]
+        selected, index = auth_with_phonemes.select_passphrase(passphrases)
+        assert index in (0, 1)
+        assert selected is passphrases[index]
 
     @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
     @patch("voice_auth_engine.passphrase_auth.transcribe")
@@ -284,7 +301,7 @@ class TestEnrollPassphrasePhonemes:
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.load_audio")
-    def test_enroll_raises_on_inconsistent_phonemes(
+    def test_raises_on_inconsistent_phonemes(
         self,
         mock_load: MagicMock,
         mock_detect: MagicMock,
@@ -316,13 +333,13 @@ class TestEnrollPassphrasePhonemes:
         )
         passphrases = [auth.extract_passphrase(audio) for _ in range(2)]
         with pytest.raises(PhonemeConsistencyError, match="音素列の不整合"):
-            auth.enroll_passphrase(passphrases)
+            auth.select_passphrase(passphrases)
 
     @patch("voice_auth_engine.passphrase_auth.load_audio")
     @patch("voice_auth_engine.passphrase_auth.extract_speech")
     @patch("voice_auth_engine.passphrase_auth.detect_speech")
     @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    def test_enroll_without_phoneme_threshold_returns_empty_phonemes(
+    def test_without_phoneme_threshold(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
@@ -330,7 +347,7 @@ class TestEnrollPassphrasePhonemes:
         mock_load: MagicMock,
         auth: PassphraseAuth,
     ) -> None:
-        """phoneme_threshold=None の場合、空の音素列を返す。"""
+        """phoneme_threshold=None でも正常に選択できる。"""
         audio = make_audio(1.0)
         mock_load.return_value = audio
         mock_detect.return_value = make_segments(audio)
@@ -338,8 +355,9 @@ class TestEnrollPassphrasePhonemes:
         mock_extract_emb.return_value = make_embedding([1.0, 0.0, 0.0])
 
         passphrases = [auth.extract_passphrase(audio)]
-        result = auth.enroll_passphrase(passphrases)
-        assert result.phoneme.values == []
+        selected, index = auth.select_passphrase(passphrases)
+        assert index == 0
+        assert selected is passphrases[0]
 
 
 class TestVerifyPassphrasePhonemes:
@@ -360,9 +378,11 @@ class TestVerifyPassphrasePhonemes:
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者一致 + 音素一致で accepted=True。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+            transcription="test",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -371,7 +391,7 @@ class TestVerifyPassphrasePhonemes:
             speech_duration=1.0,
         )
 
-        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrolled)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_accepted is True
@@ -382,9 +402,11 @@ class TestVerifyPassphrasePhonemes:
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者一致 + 音素不一致で accepted=False。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+            transcription="test",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -393,7 +415,7 @@ class TestVerifyPassphrasePhonemes:
             speech_duration=1.0,
         )
 
-        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrolled)
 
         assert result.voiceprint_accepted is False
         assert result.passphrase_accepted is False
@@ -405,9 +427,11 @@ class TestVerifyPassphrasePhonemes:
         auth_with_phoneme_gate: PassphraseAuth,
     ) -> None:
         """話者不一致 + 音素一致でも accepted=False。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=["a", "i", "u", "e", "o"]),
+            transcription="test",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([0.0, 1.0, 0.0]),
@@ -416,7 +440,7 @@ class TestVerifyPassphrasePhonemes:
             speech_duration=1.0,
         )
 
-        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrollment)
+        result = auth_with_phoneme_gate.verify_passphrase(passphrase, enrolled)
 
         assert result.voiceprint_accepted is False
         assert result.passphrase_accepted is True
@@ -424,9 +448,11 @@ class TestVerifyPassphrasePhonemes:
 
     def test_no_phoneme_threshold_skips_passphrase_check(self, auth: PassphraseAuth) -> None:
         """phoneme_threshold=None で音素照合無効。"""
-        enrollment = EnrollmentResult(
+        enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
             phoneme=Phoneme(values=[]),
+            transcription="",
+            speech_duration=1.0,
         )
         passphrase = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -435,7 +461,7 @@ class TestVerifyPassphrasePhonemes:
             speech_duration=1.0,
         )
 
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, enrolled)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_score is None

--- a/tests/test_passphrase_auth_integration.py
+++ b/tests/test_passphrase_auth_integration.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 
 from voice_auth_engine.audio_validator import EmptyAudioError, InsufficientDurationError
-from voice_auth_engine.passphrase_auth import EnrollmentResult, PassphraseAuth
+from voice_auth_engine.passphrase_auth import Passphrase, PassphraseAuth
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 
 from .audio_factory import generate_silence_samples, make_audio_data
@@ -27,10 +27,10 @@ class TestPassphraseAuthIntegration:
     def test_enroll_and_verify_same_speaker(self, auth: PassphraseAuth) -> None:
         """登録→本人認証で accepted=True。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
-        enrollment = auth.enroll_passphrase(passphrases)
+        selected, _ = auth.select_passphrase(passphrases)
 
         passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, selected)
         assert result.voiceprint_accepted is True
         assert result.voiceprint_score > auth.threshold
 
@@ -41,10 +41,10 @@ class TestPassphraseAuthIntegration:
     def test_reject_different_speaker(self, auth: PassphraseAuth, other_speaker: str) -> None:
         """登録→他人認証で accepted=False。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
-        enrollment = auth.enroll_passphrase(passphrases)
+        selected, _ = auth.select_passphrase(passphrases)
 
         passphrase = auth.extract_passphrase(FIXTURES_DIR / other_speaker)
-        result = auth.verify_passphrase(passphrase, enrollment)
+        result = auth.verify_passphrase(passphrase, selected)
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score < auth.threshold
 
@@ -57,12 +57,12 @@ class TestPassphraseAuthIntegration:
     ) -> None:
         """本人のスコアが他人のスコアより高い。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
-        enrollment = auth.enroll_passphrase(passphrases)
+        selected, _ = auth.select_passphrase(passphrases)
 
         same_passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
         diff_passphrase = auth.extract_passphrase(FIXTURES_DIR / other_speaker)
-        same_result = auth.verify_passphrase(same_passphrase, enrollment)
-        diff_result = auth.verify_passphrase(diff_passphrase, enrollment)
+        same_result = auth.verify_passphrase(same_passphrase, selected)
+        diff_result = auth.verify_passphrase(diff_passphrase, selected)
         assert same_result.voiceprint_score > diff_result.voiceprint_score
 
     def test_embedding_serialization_roundtrip(self, auth: PassphraseAuth) -> None:
@@ -70,15 +70,17 @@ class TestPassphraseAuthIntegration:
         from voice_auth_engine.embedding_extractor import Embedding
 
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
-        enrollment = auth.enroll_passphrase(passphrases)
+        selected, _ = auth.select_passphrase(passphrases)
 
-        restored = Embedding.from_bytes(enrollment.embedding.to_bytes())
-        restored_enrollment = EnrollmentResult(
+        restored = Embedding.from_bytes(selected.embedding.to_bytes())
+        restored_enrolled = Passphrase(
             embedding=restored,
-            phoneme=enrollment.phoneme,
+            phoneme=selected.phoneme,
+            transcription=selected.transcription,
+            speech_duration=selected.speech_duration,
         )
         passphrase = auth.extract_passphrase(FIXTURES_DIR / "speaker_a_verify.mp3")
-        result = auth.verify_passphrase(passphrase, restored_enrollment)
+        result = auth.verify_passphrase(passphrase, restored_enrolled)
         assert result.voiceprint_accepted is True
 
     def test_silence_raises_empty_audio_error(self, auth: PassphraseAuth) -> None:
@@ -105,32 +107,34 @@ def phoneme_auth() -> PassphraseAuth:
 class TestPhonemeVerificationIntegration:
     """音素ベースのパスフレーズ照合の統合テスト。"""
 
-    def test_enroll_with_phoneme_threshold(
+    def test_select_with_phoneme_threshold(
         self,
         phoneme_auth: PassphraseAuth,
     ) -> None:
-        """phoneme_threshold 有効で登録すると phonemes が返る。"""
+        """phoneme_threshold 有効で選択すると phonemes を含む Passphrase が返る。"""
         passphrases = [
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
         ]
-        result = phoneme_auth.enroll_passphrase(passphrases)
+        selected, index = phoneme_auth.select_passphrase(passphrases)
 
-        assert len(result.phoneme.values) > 0
+        assert len(selected.phoneme.values) > 0
+        assert selected is passphrases[index]
 
-    def test_enroll_three_samples_selects_medoid(
+    def test_select_three_samples(
         self,
         phoneme_auth: PassphraseAuth,
     ) -> None:
-        """3サンプル登録でメドイドが選択され phonemes が返る。"""
+        """3サンプルで medoid が選択される。"""
         passphrases = [
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_3.mp3"),
         ]
-        result = phoneme_auth.enroll_passphrase(passphrases)
+        selected, index = phoneme_auth.select_passphrase(passphrases)
 
-        assert len(result.phoneme.values) > 0
+        assert len(selected.phoneme.values) > 0
+        assert 0 <= index <= 2
 
     def test_same_speaker_same_passphrase_accepted(
         self,
@@ -141,10 +145,10 @@ class TestPhonemeVerificationIntegration:
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
         ]
-        enrollment = phoneme_auth.enroll_passphrase(passphrases)
+        selected, _ = phoneme_auth.select_passphrase(passphrases)
 
         passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_verify.mp3")
-        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
+        result = phoneme_auth.verify_passphrase(passphrase, selected)
 
         assert result.voiceprint_accepted is True
         assert result.passphrase_accepted is True
@@ -161,10 +165,10 @@ class TestPhonemeVerificationIntegration:
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
         ]
-        enrollment = phoneme_auth.enroll_passphrase(passphrases)
+        selected, _ = phoneme_auth.select_passphrase(passphrases)
 
         passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_b.mp3")
-        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
+        result = phoneme_auth.verify_passphrase(passphrase, selected)
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score >= phoneme_auth.threshold  # 話者は本人
@@ -179,16 +183,16 @@ class TestPhonemeVerificationIntegration:
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3"),
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3"),
         ]
-        enrollment = phoneme_auth.enroll_passphrase(passphrases)
+        selected, _ = phoneme_auth.select_passphrase(passphrases)
 
         passphrase = phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_b_phrase_a.mp3")
-        result = phoneme_auth.verify_passphrase(passphrase, enrollment)
+        result = phoneme_auth.verify_passphrase(passphrase, selected)
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score < phoneme_auth.threshold  # 話者が異なる
         assert result.passphrase_accepted is True  # 音素は一致
 
-    def test_enrollment_with_inconsistent_passphrases_raises_error(
+    def test_inconsistent_passphrases_raises_error(
         self,
         phoneme_auth: PassphraseAuth,
     ) -> None:
@@ -198,4 +202,4 @@ class TestPhonemeVerificationIntegration:
             phoneme_auth.extract_passphrase(FIXTURES_DIR / "speaker_a_phrase_b.mp3"),
         ]
         with pytest.raises(PhonemeConsistencyError):
-            phoneme_auth.enroll_passphrase(passphrases)
+            phoneme_auth.select_passphrase(passphrases)


### PR DESCRIPTION
## 概要

`enroll_passphrase()` を `select_passphrase()` にリネームし、全サンプルの平均 embedding を算出する方式から、コサイン距離に基づく medoid 選択方式に変更。

### 変更内容

- `enroll_passphrase()` → `select_passphrase()` にリネーム、戻り値を `tuple[Passphrase, int]`（選択されたパスフレーズとインデックス）に変更
- `EnrollmentResult` を削除。`verify_passphrase()` は `Passphrase` を直接受け取るように変更
- `math.py` に `cosine_distance_matrix()` を追加し、embedding 間のコサイン距離行列を計算
- embedding の medoid（他サンプルとの距離総和が最小）を選択する方式に変更

### 変更後のAPI

```python
auth = PassphraseAuth(threshold=0.5)

# 登録
passphrases = [auth.extract_passphrase(a) for a in audios]
selected, index = auth.select_passphrase(passphrases)

# 認証
passphrase = auth.extract_passphrase(audio)
result = auth.verify_passphrase(passphrase, selected)
```

Closes #71