### PR TITLE
refactor(phoneme_extractor): remove unused Phoneme.select_reference()

### DIFF
--- a/src/voice_auth_engine/phoneme_extractor.py
+++ b/src/voice_auth_engine/phoneme_extractor.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import pyopenjtalk
 
-from voice_auth_engine.math import pairwise_distances, select_medoid
 from voice_auth_engine.passphrase_validator import EmptyPassphraseError
 
 # フィルタ対象の音素記号
@@ -26,20 +25,6 @@ class Phoneme:
     def unique_count(self) -> int:
         """ユニーク音素数。"""
         return len(self.unique)
-
-    @staticmethod
-    def select_reference(samples: list[Phoneme]) -> Phoneme:
-        """複数サンプルからメドイド（基準音素）を選択する。
-
-        Args:
-            samples: 音素サンプルのリスト。
-
-        Returns:
-            メドイドとして選択された音素。
-        """
-        distances = pairwise_distances([s.values for s in samples])
-        medoid_index = select_medoid(distances)
-        return samples[medoid_index]
 
 
 def extract_phonemes(text: str) -> Phoneme:


### PR DESCRIPTION
## 概要

#71 で `select_passphrase()` が embedding のコサイン距離に基づく medoid 選択方式に変更されたため、音素の medoid 選択を行う `Phoneme.select_reference()` はどこからも呼ばれなくなった。

- `Phoneme.select_reference()` メソッドを削除
- `phoneme_extractor.py` から `pairwise_distances`, `select_medoid` の不要な import を削除

Closes #80