### PR TITLE
chore: bump version to v0.5.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voice-auth-engine"
-version = "0.5.3"
+version = "0.5.4"
 description = "Voice authentication engine"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "voice-auth-engine"
-version = "0.5.3"
+version = "0.5.4"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## 概要

v0.5.4 リリースに向けたバージョンバンプ。`pyproject.toml` および `uv.lock` のバージョンを 0.5.3 → 0.5.4 に更新。