### PR TITLE
refactor: rename PassphraseAuth to VoiceAuth

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -26,12 +26,6 @@ from voice_auth_engine.embedding_extractor import (
 from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 from voice_auth_engine.model_config import ModelConfig
 from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
-from voice_auth_engine.passphrase_auth import (
-    Passphrase,
-    PassphraseAuth,
-    PassphraseAuthError,
-    VerificationResult,
-)
 from voice_auth_engine.passphrase_validator import (
     EmptyPassphraseError,
     InsufficientPhonemeError,
@@ -59,6 +53,12 @@ from voice_auth_engine.speech_recognizer import (
     TranscriptionResult,
     transcribe,
 )
+from voice_auth_engine.voice_auth import (
+    Passphrase,
+    VerificationResult,
+    VoiceAuth,
+    VoiceAuthError,
+)
 
 __all__ = [
     "AudioData",
@@ -77,8 +77,8 @@ __all__ = [
     "ModelDownloader",
     "InsufficientDurationError",
     "InsufficientPhonemeError",
-    "PassphraseAuth",
-    "PassphraseAuthError",
+    "VoiceAuth",
+    "VoiceAuthError",
     "PhonemeConsistencyError",
     "Passphrase",
     "VerificationResult",

--- a/src/voice_auth_engine/voice_auth.py
+++ b/src/voice_auth_engine/voice_auth.py
@@ -1,4 +1,4 @@
-"""パスフレーズ方式の話者認証。"""
+"""話者認証。"""
 
 from __future__ import annotations
 
@@ -23,8 +23,8 @@ from voice_auth_engine.speech_detector import detect_speech, extract_speech
 from voice_auth_engine.speech_recognizer import transcribe
 
 
-class PassphraseAuthError(Exception):
-    """PassphraseAuth の基底例外。"""
+class VoiceAuthError(Exception):
+    """VoiceAuth の基底例外。"""
 
 
 @dataclass(frozen=True)
@@ -46,15 +46,15 @@ class VerificationResult(NamedTuple):
     passphrase_score: float | None = None  # 正規化編集距離 [0.0, 1.0]
 
 
-class PassphraseAuth:
-    """パスフレーズ方式の話者認証。
+class VoiceAuth:
+    """話者認証。
 
     音声読み込み → VAD → 発話時間チェック → 音素検証 → 埋め込み抽出の
     パイプラインと、選択・照合メソッドを提供する。
 
     使用例::
 
-        auth = PassphraseAuth(threshold=0.5)
+        auth = VoiceAuth(threshold=0.5)
 
         # 登録
         passphrases = [auth.extract_passphrase(a) for a in audios]

--- a/tests/test_voice_auth.py
+++ b/tests/test_voice_auth.py
@@ -1,4 +1,4 @@
-"""passphrase_auth モジュールのテスト。"""
+"""voice_auth モジュールのテスト。"""
 
 from __future__ import annotations
 
@@ -10,20 +10,20 @@ import pytest
 from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.audio_validator import EmptyAudioError
 from voice_auth_engine.embedding_extractor import Embedding
-from voice_auth_engine.passphrase_auth import (
-    Passphrase,
-    PassphraseAuth,
-)
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 from voice_auth_engine.phoneme_extractor import Phoneme
+from voice_auth_engine.voice_auth import (
+    Passphrase,
+    VoiceAuth,
+)
 
 from .audio_factory import make_audio, make_embedding, make_segments
 
 
 @pytest.fixture
-def auth() -> PassphraseAuth:
-    """テスト用 PassphraseAuth。"""
-    return PassphraseAuth(
+def auth() -> VoiceAuth:
+    """テスト用 VoiceAuth。"""
+    return VoiceAuth(
         threshold=0.5,
         min_speech_seconds=0.1,
         min_unique_phonemes=None,
@@ -31,19 +31,19 @@ def auth() -> PassphraseAuth:
 
 
 class TestSelectPassphrase:
-    """PassphraseAuth.select_passphrase のテスト。"""
+    """VoiceAuth.select_passphrase のテスト。"""
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
     def test_single_sample(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
         mock_load: MagicMock,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """1サンプルでそのまま返る。"""
         audio = make_audio(1.0)
@@ -58,17 +58,17 @@ class TestSelectPassphrase:
         assert selected is passphrases[0]
         np.testing.assert_array_equal(selected.embedding.values, [1.0, 0.0, 0.0])
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
     def test_multiple_samples_selects_medoid(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
         mock_load: MagicMock,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """複数サンプルで medoid が選択される。"""
         audio = make_audio(1.0)
@@ -87,20 +87,20 @@ class TestSelectPassphrase:
         assert index in (0, 1)
         assert selected is passphrases[index]
 
-    def test_empty_raises(self, auth: PassphraseAuth) -> None:
+    def test_empty_raises(self, auth: VoiceAuth) -> None:
         """空リストで ValueError。"""
         with pytest.raises(ValueError, match="passphrases が空です"):
             auth.select_passphrase([])
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
     def test_extract_no_speech_raises(
         self,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
         mock_load: MagicMock,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """VAD で音声なしの場合 EmptyAudioError。"""
         audio = make_audio(1.0)
@@ -113,17 +113,17 @@ class TestSelectPassphrase:
         with pytest.raises(EmptyAudioError):
             auth.extract_passphrase(audio)
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
     def test_returns_passphrase_and_index(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
         mock_load: MagicMock,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """select_passphrase() が tuple[Passphrase, int] を返す。"""
         audio = make_audio(1.0)
@@ -139,9 +139,9 @@ class TestSelectPassphrase:
 
 
 class TestVerifyPassphrase:
-    """PassphraseAuth.verify_passphrase のテスト。"""
+    """VoiceAuth.verify_passphrase のテスト。"""
 
-    def test_verify_accepted(self, auth: PassphraseAuth) -> None:
+    def test_verify_accepted(self, auth: VoiceAuth) -> None:
         """類似度 >= threshold で accepted=True。"""
         enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -160,7 +160,7 @@ class TestVerifyPassphrase:
         assert result.voiceprint_accepted is True
         assert result.voiceprint_score == pytest.approx(1.0)
 
-    def test_verify_rejected(self, auth: PassphraseAuth) -> None:
+    def test_verify_rejected(self, auth: VoiceAuth) -> None:
         """類似度 < threshold で accepted=False。"""
         enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -184,9 +184,9 @@ class TestSelectPassphrasePhonemes:
     """select_passphrase の音素整合性チェックのテスト。"""
 
     @pytest.fixture
-    def auth_with_phonemes(self) -> PassphraseAuth:
-        """phoneme_threshold 有効の PassphraseAuth。"""
-        return PassphraseAuth(
+    def auth_with_phonemes(self) -> VoiceAuth:
+        """phoneme_threshold 有効の VoiceAuth。"""
+        return VoiceAuth(
             threshold=0.5,
             min_speech_seconds=0.1,
             min_unique_phonemes=None,
@@ -220,12 +220,12 @@ class TestSelectPassphrasePhonemes:
         mock_extract_phonemes.side_effect = [Phoneme(values=p) for p in phoneme_lists]
         return audio
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_phonemes")
+    @patch("voice_auth_engine.voice_auth.transcribe")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.load_audio")
     def test_extract_passphrase_returns_phonemes(
         self,
         mock_load: MagicMock,
@@ -234,7 +234,7 @@ class TestSelectPassphrasePhonemes:
         mock_extract_emb: MagicMock,
         mock_transcribe: MagicMock,
         mock_extract_phonemes: MagicMock,
-        auth_with_phonemes: PassphraseAuth,
+        auth_with_phonemes: VoiceAuth,
     ) -> None:
         """extract_passphrase が音素列を含む結果を返す。"""
         phonemes = ["a", "i", "u", "e", "o"]
@@ -251,12 +251,12 @@ class TestSelectPassphrasePhonemes:
         assert result.phoneme.values == phonemes
         assert isinstance(result.embedding, Embedding)
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_phonemes")
+    @patch("voice_auth_engine.voice_auth.transcribe")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.load_audio")
     def test_selects_medoid_by_embedding(
         self,
         mock_load: MagicMock,
@@ -265,7 +265,7 @@ class TestSelectPassphrasePhonemes:
         mock_extract_emb: MagicMock,
         mock_transcribe: MagicMock,
         mock_extract_phonemes: MagicMock,
-        auth_with_phonemes: PassphraseAuth,
+        auth_with_phonemes: VoiceAuth,
     ) -> None:
         """select_passphrase() が embedding の medoid でサンプルを選択する。"""
         # サンプル0,1は近い embedding、サンプル2は遠い
@@ -295,12 +295,12 @@ class TestSelectPassphrasePhonemes:
         assert index in (0, 1)
         assert selected is passphrases[index]
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_phonemes")
+    @patch("voice_auth_engine.voice_auth.transcribe")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.load_audio")
     def test_raises_on_inconsistent_phonemes(
         self,
         mock_load: MagicMock,
@@ -311,7 +311,7 @@ class TestSelectPassphrasePhonemes:
         mock_extract_phonemes: MagicMock,
     ) -> None:
         """音素列の距離が閾値を超えると PhonemeConsistencyError。"""
-        auth = PassphraseAuth(
+        auth = VoiceAuth(
             threshold=0.5,
             min_speech_seconds=0.1,
             min_unique_phonemes=None,
@@ -335,17 +335,17 @@ class TestSelectPassphrasePhonemes:
         with pytest.raises(PhonemeConsistencyError, match="音素列の不整合"):
             auth.select_passphrase(passphrases)
 
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
     def test_without_phoneme_threshold(
         self,
         mock_extract_emb: MagicMock,
         mock_detect: MagicMock,
         mock_extract_sp: MagicMock,
         mock_load: MagicMock,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """phoneme_threshold=None でも正常に選択できる。"""
         audio = make_audio(1.0)
@@ -364,9 +364,9 @@ class TestVerifyPassphrasePhonemes:
     """verify_passphrase の音素照合ゲート付きテスト。"""
 
     @pytest.fixture
-    def auth_with_phoneme_gate(self) -> PassphraseAuth:
-        """phoneme_threshold 有効の PassphraseAuth。"""
-        return PassphraseAuth(
+    def auth_with_phoneme_gate(self) -> VoiceAuth:
+        """phoneme_threshold 有効の VoiceAuth。"""
+        return VoiceAuth(
             threshold=0.5,
             min_speech_seconds=0.1,
             min_unique_phonemes=None,
@@ -375,7 +375,7 @@ class TestVerifyPassphrasePhonemes:
 
     def test_phoneme_match_accepted(
         self,
-        auth_with_phoneme_gate: PassphraseAuth,
+        auth_with_phoneme_gate: VoiceAuth,
     ) -> None:
         """話者一致 + 音素一致で accepted=True。"""
         enrolled = Passphrase(
@@ -399,7 +399,7 @@ class TestVerifyPassphrasePhonemes:
 
     def test_phoneme_mismatch_rejected(
         self,
-        auth_with_phoneme_gate: PassphraseAuth,
+        auth_with_phoneme_gate: VoiceAuth,
     ) -> None:
         """話者一致 + 音素不一致で accepted=False。"""
         enrolled = Passphrase(
@@ -424,7 +424,7 @@ class TestVerifyPassphrasePhonemes:
 
     def test_speaker_mismatch_with_phoneme_match_rejected(
         self,
-        auth_with_phoneme_gate: PassphraseAuth,
+        auth_with_phoneme_gate: VoiceAuth,
     ) -> None:
         """話者不一致 + 音素一致でも accepted=False。"""
         enrolled = Passphrase(
@@ -446,7 +446,7 @@ class TestVerifyPassphrasePhonemes:
         assert result.passphrase_accepted is True
         assert result.voiceprint_score == pytest.approx(0.0)
 
-    def test_no_phoneme_threshold_skips_passphrase_check(self, auth: PassphraseAuth) -> None:
+    def test_no_phoneme_threshold_skips_passphrase_check(self, auth: VoiceAuth) -> None:
         """phoneme_threshold=None で音素照合無効。"""
         enrolled = Passphrase(
             embedding=make_embedding([1.0, 0.0, 0.0]),
@@ -471,12 +471,12 @@ class TestVerifyPassphrasePhonemes:
 class TestExtractPassphrase:
     """extract_passphrase の戻り値テスト。"""
 
-    @patch("voice_auth_engine.passphrase_auth.extract_phonemes")
-    @patch("voice_auth_engine.passphrase_auth.transcribe")
-    @patch("voice_auth_engine.passphrase_auth.extract_embedding")
-    @patch("voice_auth_engine.passphrase_auth.extract_speech")
-    @patch("voice_auth_engine.passphrase_auth.detect_speech")
-    @patch("voice_auth_engine.passphrase_auth.load_audio")
+    @patch("voice_auth_engine.voice_auth.extract_phonemes")
+    @patch("voice_auth_engine.voice_auth.transcribe")
+    @patch("voice_auth_engine.voice_auth.extract_embedding")
+    @patch("voice_auth_engine.voice_auth.extract_speech")
+    @patch("voice_auth_engine.voice_auth.detect_speech")
+    @patch("voice_auth_engine.voice_auth.load_audio")
     def test_result_contains_all_fields(
         self,
         mock_load: MagicMock,
@@ -487,7 +487,7 @@ class TestExtractPassphrase:
         mock_extract_phonemes: MagicMock,
     ) -> None:
         """全フィールド（embedding, phoneme, transcription, speech_duration）が返る。"""
-        auth = PassphraseAuth(
+        auth = VoiceAuth(
             threshold=0.5,
             min_speech_seconds=0.1,
             min_unique_phonemes=5,

--- a/tests/test_voice_auth_integration.py
+++ b/tests/test_voice_auth_integration.py
@@ -1,4 +1,4 @@
-"""passphrase_auth モジュールの統合テスト（実音声）。"""
+"""voice_auth モジュールの統合テスト（実音声）。"""
 
 from __future__ import annotations
 
@@ -7,8 +7,8 @@ from pathlib import Path
 import pytest
 
 from voice_auth_engine.audio_validator import EmptyAudioError, InsufficientDurationError
-from voice_auth_engine.passphrase_auth import Passphrase, PassphraseAuth
 from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
+from voice_auth_engine.voice_auth import Passphrase, VoiceAuth
 
 from .audio_factory import generate_silence_samples, make_audio_data
 
@@ -16,15 +16,15 @@ FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
 @pytest.fixture
-def auth() -> PassphraseAuth:
-    """統合テスト用 PassphraseAuth。"""
-    return PassphraseAuth(threshold=0.8)
+def auth() -> VoiceAuth:
+    """統合テスト用 VoiceAuth。"""
+    return VoiceAuth(threshold=0.8)
 
 
-class TestPassphraseAuthIntegration:
+class TestVoiceAuthIntegration:
     """実音声を使ったパスフレーズ認証の統合テスト。"""
 
-    def test_enroll_and_verify_same_speaker(self, auth: PassphraseAuth) -> None:
+    def test_enroll_and_verify_same_speaker(self, auth: VoiceAuth) -> None:
         """登録→本人認証で accepted=True。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
         selected, _ = auth.select_passphrase(passphrases)
@@ -38,7 +38,7 @@ class TestPassphraseAuthIntegration:
         "other_speaker",
         ["speaker_b_verify.mp3", "speaker_c_verify.mp3", "speaker_d_verify.mp3"],
     )
-    def test_reject_different_speaker(self, auth: PassphraseAuth, other_speaker: str) -> None:
+    def test_reject_different_speaker(self, auth: VoiceAuth, other_speaker: str) -> None:
         """登録→他人認証で accepted=False。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
         selected, _ = auth.select_passphrase(passphrases)
@@ -53,7 +53,7 @@ class TestPassphraseAuthIntegration:
         ["speaker_b_verify.mp3", "speaker_c_verify.mp3", "speaker_d_verify.mp3"],
     )
     def test_same_speaker_score_higher_than_different_speaker(
-        self, auth: PassphraseAuth, other_speaker: str
+        self, auth: VoiceAuth, other_speaker: str
     ) -> None:
         """本人のスコアが他人のスコアより高い。"""
         passphrases = [auth.extract_passphrase(FIXTURES_DIR / "speaker_a_enroll.mp3")]
@@ -65,7 +65,7 @@ class TestPassphraseAuthIntegration:
         diff_result = auth.verify_passphrase(diff_passphrase, selected)
         assert same_result.voiceprint_score > diff_result.voiceprint_score
 
-    def test_embedding_serialization_roundtrip(self, auth: PassphraseAuth) -> None:
+    def test_embedding_serialization_roundtrip(self, auth: VoiceAuth) -> None:
         """埋め込みベクトルのシリアライズ→デシリアライズ後も認証可能。"""
         from voice_auth_engine.embedding_extractor import Embedding
 
@@ -83,7 +83,7 @@ class TestPassphraseAuthIntegration:
         result = auth.verify_passphrase(passphrase, restored_enrolled)
         assert result.voiceprint_accepted is True
 
-    def test_silence_raises_empty_audio_error(self, auth: PassphraseAuth) -> None:
+    def test_silence_raises_empty_audio_error(self, auth: VoiceAuth) -> None:
         """無音音声で EmptyAudioError が発生する。"""
         silence = make_audio_data(generate_silence_samples(duration=5.0))
         with pytest.raises(EmptyAudioError):
@@ -91,7 +91,7 @@ class TestPassphraseAuthIntegration:
 
     def test_short_speech_raises_insufficient_duration_error(
         self,
-        auth: PassphraseAuth,
+        auth: VoiceAuth,
     ) -> None:
         """発話時間が短い音声で InsufficientDurationError が発生する。"""
         with pytest.raises(InsufficientDurationError):
@@ -99,9 +99,9 @@ class TestPassphraseAuthIntegration:
 
 
 @pytest.fixture
-def phoneme_auth() -> PassphraseAuth:
-    """音素照合を有効にした統合テスト用 PassphraseAuth。"""
-    return PassphraseAuth(threshold=0.8, phoneme_threshold=0.3)
+def phoneme_auth() -> VoiceAuth:
+    """音素照合を有効にした統合テスト用 VoiceAuth。"""
+    return VoiceAuth(threshold=0.8, phoneme_threshold=0.3)
 
 
 class TestPhonemeVerificationIntegration:
@@ -109,7 +109,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_select_with_phoneme_threshold(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """phoneme_threshold 有効で選択すると phonemes を含む Passphrase が返る。"""
         passphrases = [
@@ -123,7 +123,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_select_three_samples(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """3サンプルで medoid が選択される。"""
         passphrases = [
@@ -138,7 +138,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_same_speaker_same_passphrase_accepted(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """本人+同一パスフレーズで accepted=True, passphrase_accepted=True。"""
         passphrases = [
@@ -158,7 +158,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_same_speaker_different_passphrase_rejected(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """本人+異なるパスフレーズで accepted=False（話者OK, 音素NG）。"""
         passphrases = [
@@ -176,7 +176,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_different_speaker_same_passphrase_rejected(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """他人+同一パスフレーズで accepted=False（話者NG, 音素OK）。"""
         passphrases = [
@@ -194,7 +194,7 @@ class TestPhonemeVerificationIntegration:
 
     def test_inconsistent_passphrases_raises_error(
         self,
-        phoneme_auth: PassphraseAuth,
+        phoneme_auth: VoiceAuth,
     ) -> None:
         """異なるパスフレーズで登録すると PhonemeConsistencyError。"""
         passphrases = [


### PR DESCRIPTION
## 概要

`PassphraseAuth` の認証ロジック（声紋 medoid 選択、コサイン類似度照合、音素整合性チェック）は汎用的な話者認証であり、「パスフレーズ」というドメイン概念に依存していないため、クラス名・モジュール名をリネームする。

| 変更前 | 変更後 |
|---|---|
| `passphrase_auth.py` | `voice_auth.py` |
| `PassphraseAuth` | `VoiceAuth` |
| `PassphraseAuthError` | `VoiceAuthError` |
| `test_passphrase_auth.py` | `test_voice_auth.py` |
| `test_passphrase_auth_integration.py` | `test_voice_auth_integration.py` |

`passphrase_validator.py` はパスフレーズ品質担保のロジックのためリネーム対象外。

Closes #84