### PR TITLE
refactor: rename passphrase naming to phoneme (#86)

### DIFF
--- a/src/voice_auth_engine/__init__.py
+++ b/src/voice_auth_engine/__init__.py
@@ -26,17 +26,17 @@ from voice_auth_engine.embedding_extractor import (
 from voice_auth_engine.math import cosine_similarity, normalized_edit_distance
 from voice_auth_engine.model_config import ModelConfig
 from voice_auth_engine.model_downloader import ModelDownloader, ModelDownloadError
-from voice_auth_engine.passphrase_validator import (
-    EmptyPassphraseError,
-    InsufficientPhonemeError,
-    PassphraseValidationError,
-    PhonemeConsistencyError,
-    validate_passphrase,
-    validate_phoneme_consistency,
-)
 from voice_auth_engine.phoneme_extractor import (
     Phoneme,
     extract_phonemes,
+)
+from voice_auth_engine.phoneme_validator import (
+    EmptyPhonemeError,
+    InsufficientPhonemeError,
+    PhonemeConsistencyError,
+    PhonemeValidationError,
+    validate_phoneme,
+    validate_phoneme_consistency,
 )
 from voice_auth_engine.speech_detector import (
     SpeechDetectorError,
@@ -73,7 +73,7 @@ __all__ = [
     "EmbeddingExtractorError",
     "EmbeddingModelLoadError",
     "EmptyAudioError",
-    "EmptyPassphraseError",
+    "EmptyPhonemeError",
     "ModelDownloadError",
     "ModelDownloader",
     "InsufficientDurationError",
@@ -85,7 +85,7 @@ __all__ = [
     "VoiceInput",
     "VerificationResult",
     "Phoneme",
-    "PassphraseValidationError",
+    "PhonemeValidationError",
     "RecognitionError",
     "RecognizerModelLoadError",
     "SpeechDetectorError",
@@ -108,6 +108,6 @@ __all__ = [
     "transcribe",
     "validate_audio",
     "validate_extension",
-    "validate_passphrase",
+    "validate_phoneme",
     "validate_phoneme_consistency",
 ]

--- a/src/voice_auth_engine/phoneme_extractor.py
+++ b/src/voice_auth_engine/phoneme_extractor.py
@@ -1,10 +1,10 @@
-"""pyopenjtalk を使用した日本語パスフレーズの音素抽出。"""
+"""pyopenjtalk を使用した日本語テキストの音素抽出。"""
 
 from __future__ import annotations
 
 import pyopenjtalk
 
-from voice_auth_engine.passphrase_validator import EmptyPassphraseError
+from voice_auth_engine.phoneme_validator import EmptyPhonemeError
 
 # フィルタ対象の音素記号
 _FILTERED_PHONEMES: frozenset[str] = frozenset({"pau", "cl"})
@@ -28,19 +28,19 @@ class Phoneme:
 
 
 def extract_phonemes(text: str) -> Phoneme:
-    """パスフレーズから音素を抽出する。
+    """テキストから音素を抽出する。
 
     Args:
-        text: パスフレーズのテキスト。
+        text: 入力テキスト。
 
     Returns:
         Phoneme: 音素解析結果。
 
     Raises:
-        EmptyPassphraseError: テキストが空または空白のみの場合。
+        EmptyPhonemeError: テキストが空または空白のみの場合。
     """
     if not text.strip():
-        raise EmptyPassphraseError("パスフレーズが空です")
+        raise EmptyPhonemeError("テキストが空です")
 
     raw_phonemes: list[str] = pyopenjtalk.g2p(text, join=False)
     phonemes = [p for p in raw_phonemes if p not in _FILTERED_PHONEMES]

--- a/src/voice_auth_engine/phoneme_validator.py
+++ b/src/voice_auth_engine/phoneme_validator.py
@@ -1,4 +1,4 @@
-"""日本語パスフレーズの音素多様性バリデーション。"""
+"""日本語音素の多様性バリデーション。"""
 
 from __future__ import annotations
 
@@ -10,15 +10,15 @@ if TYPE_CHECKING:
     from voice_auth_engine.phoneme_extractor import Phoneme
 
 
-class PassphraseValidationError(Exception):
-    """パスフレーズバリデーションの基底例外。"""
+class PhonemeValidationError(Exception):
+    """音素バリデーションの基底例外。"""
 
 
-class EmptyPassphraseError(PassphraseValidationError):
-    """パスフレーズが空。"""
+class EmptyPhonemeError(PhonemeValidationError):
+    """音素が空。"""
 
 
-class InsufficientPhonemeError(PassphraseValidationError):
+class InsufficientPhonemeError(PhonemeValidationError):
     """ユニーク音素数が不足。"""
 
     def __init__(self, phoneme: Phoneme, min_required: int) -> None:
@@ -27,11 +27,11 @@ class InsufficientPhonemeError(PassphraseValidationError):
         super().__init__(f"ユニーク音素数が不足しています: {phoneme.unique_count} < {min_required}")
 
 
-class PhonemeConsistencyError(PassphraseValidationError):
+class PhonemeConsistencyError(PhonemeValidationError):
     """音素列の整合性チェック失敗。"""
 
 
-def validate_passphrase(phoneme: Phoneme, *, min_unique_phonemes: int) -> None:
+def validate_phoneme(phoneme: Phoneme, *, min_unique_phonemes: int) -> None:
     """音素解析結果のユニーク音素数を検証する。
 
     Args:

--- a/src/voice_auth_engine/voice_auth.py
+++ b/src/voice_auth_engine/voice_auth.py
@@ -13,11 +13,11 @@ from voice_auth_engine.math import (
     normalized_edit_distance,
     select_medoid,
 )
-from voice_auth_engine.passphrase_validator import (
-    validate_passphrase,
+from voice_auth_engine.phoneme_extractor import Phoneme, extract_phonemes
+from voice_auth_engine.phoneme_validator import (
+    validate_phoneme,
     validate_phoneme_consistency,
 )
-from voice_auth_engine.phoneme_extractor import Phoneme, extract_phonemes
 from voice_auth_engine.speech_detector import detect_speech, extract_speech
 from voice_auth_engine.speech_recognizer import transcribe
 
@@ -47,8 +47,8 @@ class VerificationResult(NamedTuple):
 
     voiceprint_accepted: bool  # 受理/拒否
     voiceprint_score: float  # コサイン類似度 [-1.0, 1.0]
-    passphrase_accepted: bool | None = None  # 音素照合の受理/拒否
-    passphrase_score: float | None = None  # 正規化編集距離 [0.0, 1.0]
+    phoneme_accepted: bool | None = None  # 音素照合の受理/拒否
+    phoneme_score: float | None = None  # 正規化編集距離 [0.0, 1.0]
 
 
 class VoiceAuth:
@@ -149,16 +149,16 @@ class VoiceAuth:
         speaker_accepted = score >= self._threshold
 
         if self._phoneme_threshold is not None:
-            passphrase_score = normalized_edit_distance(
+            phoneme_score = normalized_edit_distance(
                 reference["phoneme_values"], target["phoneme_values"]
             )
-            passphrase_accepted = passphrase_score <= self._phoneme_threshold
-            voiceprint_accepted = speaker_accepted and passphrase_accepted
+            phoneme_accepted = phoneme_score <= self._phoneme_threshold
+            voiceprint_accepted = speaker_accepted and phoneme_accepted
             return VerificationResult(
                 voiceprint_accepted=voiceprint_accepted,
                 voiceprint_score=score,
-                passphrase_score=passphrase_score,
-                passphrase_accepted=passphrase_accepted,
+                phoneme_score=phoneme_score,
+                phoneme_accepted=phoneme_accepted,
             )
 
         return VerificationResult(voiceprint_accepted=speaker_accepted, voiceprint_score=score)
@@ -188,7 +188,7 @@ class VoiceAuth:
             transcription_text = result.text
             phoneme = extract_phonemes(result.text)
             if self._min_unique_phonemes is not None:
-                validate_passphrase(phoneme, min_unique_phonemes=self._min_unique_phonemes)
+                validate_phoneme(phoneme, min_unique_phonemes=self._min_unique_phonemes)
         else:
             transcription_text = ""
             phoneme = Phoneme(values=[])

--- a/tests/test_phoneme_extractor.py
+++ b/tests/test_phoneme_extractor.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from voice_auth_engine.passphrase_validator import EmptyPassphraseError
 from voice_auth_engine.phoneme_extractor import (
     Phoneme,
     extract_phonemes,
 )
+from voice_auth_engine.phoneme_validator import EmptyPhonemeError
 
 
 class TestExtractPhonemes:
@@ -35,11 +35,11 @@ class TestExtractPhonemes:
         assert "cl" not in phoneme.values
 
     def test_empty_string_raises_error(self) -> None:
-        """空文字で EmptyPassphraseError が発生する。"""
-        with pytest.raises(EmptyPassphraseError):
+        """空文字で EmptyPhonemeError が発生する。"""
+        with pytest.raises(EmptyPhonemeError):
             extract_phonemes("")
 
     def test_whitespace_only_raises_error(self) -> None:
-        """空白のみで EmptyPassphraseError が発生する。"""
-        with pytest.raises(EmptyPassphraseError):
+        """空白のみで EmptyPhonemeError が発生する。"""
+        with pytest.raises(EmptyPhonemeError):
             extract_phonemes("   ")

--- a/tests/test_phoneme_validator.py
+++ b/tests/test_phoneme_validator.py
@@ -1,33 +1,33 @@
-"""passphrase_validator モジュールのテスト。"""
+"""phoneme_validator モジュールのテスト。"""
 
 import pytest
 
-from voice_auth_engine.passphrase_validator import (
-    InsufficientPhonemeError,
-    validate_passphrase,
-)
 from voice_auth_engine.phoneme_extractor import Phoneme
+from voice_auth_engine.phoneme_validator import (
+    InsufficientPhonemeError,
+    validate_phoneme,
+)
 
 
-class TestValidatePassphrase:
-    """validate_passphrase のテスト。"""
+class TestValidatePhoneme:
+    """validate_phoneme のテスト。"""
 
     def test_passes_with_sufficient_phonemes(self) -> None:
         """十分なユニーク音素数で例外が発生しない。"""
         phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
-        validate_passphrase(phoneme, min_unique_phonemes=5)
+        validate_phoneme(phoneme, min_unique_phonemes=5)
 
     def test_raises_with_insufficient_phonemes(self) -> None:
         """ユニーク音素数不足で InsufficientPhonemeError が発生する。"""
         phoneme = Phoneme(values=["a", "i"])
         with pytest.raises(InsufficientPhonemeError):
-            validate_passphrase(phoneme, min_unique_phonemes=5)
+            validate_phoneme(phoneme, min_unique_phonemes=5)
 
     def test_error_contains_phoneme(self) -> None:
         """例外に phoneme と min_required が含まれる。"""
         phoneme = Phoneme(values=["a"])
         with pytest.raises(InsufficientPhonemeError) as exc_info:
-            validate_passphrase(phoneme, min_unique_phonemes=100)
+            validate_phoneme(phoneme, min_unique_phonemes=100)
         err = exc_info.value
         assert err.phoneme is phoneme
         assert err.min_required == 100
@@ -35,10 +35,10 @@ class TestValidatePassphrase:
     def test_boundary_exact_minimum(self) -> None:
         """境界値（ちょうど閾値）で通過する。"""
         phoneme = Phoneme(values=["a", "i", "u", "e", "o"])
-        validate_passphrase(phoneme, min_unique_phonemes=5)
+        validate_phoneme(phoneme, min_unique_phonemes=5)
 
     def test_boundary_one_below_minimum(self) -> None:
         """境界値（閾値-1）で例外が発生する。"""
         phoneme = Phoneme(values=["a", "i", "u", "e"])
         with pytest.raises(InsufficientPhonemeError):
-            validate_passphrase(phoneme, min_unique_phonemes=5)
+            validate_phoneme(phoneme, min_unique_phonemes=5)

--- a/tests/test_voice_auth.py
+++ b/tests/test_voice_auth.py
@@ -9,8 +9,8 @@ import pytest
 
 from voice_auth_engine.audio_preprocessor import AudioData
 from voice_auth_engine.audio_validator import EmptyAudioError
-from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
 from voice_auth_engine.phoneme_extractor import Phoneme
+from voice_auth_engine.phoneme_validator import PhonemeConsistencyError
 from voice_auth_engine.voice_auth import (
     ExtractionResult,
     VoiceAuth,
@@ -391,8 +391,8 @@ class TestVerifyPhonemes:
         result = auth_with_phoneme_gate.verify_voice(target, reference)
 
         assert result.voiceprint_accepted is True
-        assert result.passphrase_accepted is True
-        assert result.passphrase_score == pytest.approx(0.0)
+        assert result.phoneme_accepted is True
+        assert result.phoneme_score == pytest.approx(0.0)
 
     def test_phoneme_mismatch_rejected(
         self,
@@ -411,9 +411,9 @@ class TestVerifyPhonemes:
         result = auth_with_phoneme_gate.verify_voice(target, reference)
 
         assert result.voiceprint_accepted is False
-        assert result.passphrase_accepted is False
-        assert result.passphrase_score is not None
-        assert result.passphrase_score > 0.3
+        assert result.phoneme_accepted is False
+        assert result.phoneme_score is not None
+        assert result.phoneme_score > 0.3
 
     def test_speaker_mismatch_with_phoneme_match_rejected(
         self,
@@ -432,10 +432,10 @@ class TestVerifyPhonemes:
         result = auth_with_phoneme_gate.verify_voice(target, reference)
 
         assert result.voiceprint_accepted is False
-        assert result.passphrase_accepted is True
+        assert result.phoneme_accepted is True
         assert result.voiceprint_score == pytest.approx(0.0)
 
-    def test_no_phoneme_threshold_skips_passphrase_check(self, auth: VoiceAuth) -> None:
+    def test_no_phoneme_threshold_skips_phoneme_check(self, auth: VoiceAuth) -> None:
         """phoneme_threshold=None で音素照合無効。"""
         reference: VoiceInput = {
             "embedding_values": list(make_embedding([1.0, 0.0, 0.0]).values),
@@ -449,8 +449,8 @@ class TestVerifyPhonemes:
         result = auth.verify_voice(target, reference)
 
         assert result.voiceprint_accepted is True
-        assert result.passphrase_score is None
-        assert result.passphrase_accepted is None
+        assert result.phoneme_score is None
+        assert result.phoneme_accepted is None
 
 
 class TestExtract:

--- a/tests/test_voice_auth_integration.py
+++ b/tests/test_voice_auth_integration.py
@@ -9,7 +9,7 @@ import pytest
 
 from voice_auth_engine.audio_validator import EmptyAudioError, InsufficientDurationError
 from voice_auth_engine.embedding_extractor import Embedding
-from voice_auth_engine.passphrase_validator import PhonemeConsistencyError
+from voice_auth_engine.phoneme_validator import PhonemeConsistencyError
 from voice_auth_engine.voice_auth import ExtractionResult, VoiceAuth, VoiceInput
 
 from .audio_factory import generate_silence_samples, make_audio_data
@@ -113,7 +113,7 @@ def phoneme_auth() -> VoiceAuth:
 
 
 class TestPhonemeVerificationIntegration:
-    """音素ベースのパスフレーズ照合の統合テスト。"""
+    """音素ベースの照合の統合テスト。"""
 
     def test_select_with_phoneme_threshold(
         self,
@@ -144,11 +144,11 @@ class TestPhonemeVerificationIntegration:
         assert len(selected["phoneme_values"]) > 0
         assert 0 <= index <= 2
 
-    def test_same_speaker_same_passphrase_accepted(
+    def test_same_speaker_same_phoneme_accepted(
         self,
         phoneme_auth: VoiceAuth,
     ) -> None:
-        """本人+同一パスフレーズで accepted=True, passphrase_accepted=True。"""
+        """本人+同一音素で accepted=True, phoneme_accepted=True。"""
         voices = [
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")),
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")),
@@ -161,16 +161,16 @@ class TestPhonemeVerificationIntegration:
         result = phoneme_auth.verify_voice(target, selected)
 
         assert result.voiceprint_accepted is True
-        assert result.passphrase_accepted is True
-        assert result.passphrase_score is not None
+        assert result.phoneme_accepted is True
+        assert result.phoneme_score is not None
         assert phoneme_auth._phoneme_threshold is not None
-        assert result.passphrase_score <= phoneme_auth._phoneme_threshold
+        assert result.phoneme_score <= phoneme_auth._phoneme_threshold
 
-    def test_same_speaker_different_passphrase_rejected(
+    def test_same_speaker_different_phoneme_rejected(
         self,
         phoneme_auth: VoiceAuth,
     ) -> None:
-        """本人+異なるパスフレーズで accepted=False（話者OK, 音素NG）。"""
+        """本人+異なる音素で accepted=False（話者OK, 音素NG）。"""
         voices = [
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")),
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")),
@@ -184,13 +184,13 @@ class TestPhonemeVerificationIntegration:
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score >= phoneme_auth.threshold  # 話者は本人
-        assert result.passphrase_accepted is False  # 音素が不一致
+        assert result.phoneme_accepted is False  # 音素が不一致
 
-    def test_different_speaker_same_passphrase_rejected(
+    def test_different_speaker_same_phoneme_rejected(
         self,
         phoneme_auth: VoiceAuth,
     ) -> None:
-        """他人+同一パスフレーズで accepted=False（話者NG, 音素OK）。"""
+        """他人+同一音素で accepted=False（話者NG, 音素OK）。"""
         voices = [
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")),
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_2.mp3")),
@@ -204,13 +204,13 @@ class TestPhonemeVerificationIntegration:
 
         assert result.voiceprint_accepted is False
         assert result.voiceprint_score < phoneme_auth.threshold  # 話者が異なる
-        assert result.passphrase_accepted is True  # 音素は一致
+        assert result.phoneme_accepted is True  # 音素は一致
 
-    def test_inconsistent_passphrases_raises_error(
+    def test_inconsistent_phonemes_raises_error(
         self,
         phoneme_auth: VoiceAuth,
     ) -> None:
-        """異なるパスフレーズで登録すると PhonemeConsistencyError。"""
+        """異なる音素で登録すると PhonemeConsistencyError。"""
         voices = [
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_a_1.mp3")),
             _to_voice_input(phoneme_auth.extract_audio(FIXTURES_DIR / "speaker_a_phrase_b.mp3")),


### PR DESCRIPTION
## 概要

#83 で主要クラスのリネームは完了したが、コードベースに残存していた `passphrase` 命名を `phoneme` に統一するリファクタリング。

### 変更内容

- `passphrase_validator.py` → `phoneme_validator.py`（ファイル名）
- `PassphraseValidationError` → `PhonemeValidationError`（基底例外クラス）
- `EmptyPassphraseError` → `EmptyPhonemeError`（例外クラス）
- `validate_passphrase()` → `validate_phoneme()`（関数名）
- `VerificationResult.passphrase_accepted` / `passphrase_score` → `phoneme_accepted` / `phoneme_score`（フィールド名）
- テストメソッド名・docstring の `passphrase` / `パスフレーズ` 表記を修正

Closes #86