### PR TITLE
chore: bump version to 0.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "voice-auth-engine"
-version = "0.5.4"
+version = "0.6.0"
 description = "Voice authentication engine"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "voice-auth-engine"
-version = "0.5.4"
+version = "0.6.0"
 source = { editable = "." }
 dependencies = [
     { name = "av" },


### PR DESCRIPTION
## 概要

破壊的変更を含むリネーム対応（#84, #85, #86, #87, #88）のリリースに向けて、バージョンを v0.5.4 → v0.6.0 にバンプする。

Closes #89